### PR TITLE
feat(Interaction): add rigidbody to controller option

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/SteamVR_InteractTouch.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/SteamVR_InteractTouch.cs
@@ -76,8 +76,8 @@ public class SteamVR_InteractTouch : MonoBehaviour {
 
         //Create trigger box collider for controller
         SphereCollider collider = this.gameObject.AddComponent<SphereCollider>();
-        collider.radius = 0.05f;
-        collider.center = new Vector3(0f, -0.035f, -0.01f);
+        collider.radius = 0.06f;
+        collider.center = new Vector3(0f, -0.04f, 0f);
         collider.isTrigger = true;
     }
 

--- a/README.md
+++ b/README.md
@@ -773,6 +773,10 @@ The following script parameters are available:
   grab button can be pressed before the controller touches the object
   and when the collision takes place, if the grab button is still being
   held down then the grab action will be successful.
+  * **Create Rigid Body When Not Touching:** If this is checked and the
+  controller is not touching an Interactable Object when the grab
+  button is pressed then a rigid body is added to the controller to
+  allow the controller to push other rigid body objects around.
 
 The following events are emitted:
 


### PR DESCRIPTION
There is now an option on the `InteractGrab` script that enables a
rigidbody on the controller object if the grab button is pressed when
the controller is not touching any Interactable Objects. This means
that the controller can be used to interact with other rigidbodies
to push them around or press them (e.g. a button).