### PR TITLE
fix(Controller): correct haptic duration argument

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_ControllerActions.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_ControllerActions.cs
@@ -3,13 +3,11 @@ using System.Collections;
 
 public class VRTK_ControllerActions : MonoBehaviour {
     private bool controllerVisible = true;
-    private ushort hapticPulseStrength;
-    private int hapticPulseCountdown;
+    private float hapticPulseCountdown;
 
     private uint controllerIndex;
     private SteamVR_TrackedObject trackedController;
     private SteamVR_Controller.Device device;
-    private ushort maxHapticVibration = 3999;
 
     public bool IsControllerVisible()
     {
@@ -36,10 +34,8 @@ public class VRTK_ControllerActions : MonoBehaviour {
         controllerVisible = on;
     }
 
-    public void TriggerHapticPulse(int duration, ushort strength)
     {
-        hapticPulseCountdown = duration;
-        hapticPulseStrength = (strength <= maxHapticVibration ? strength : maxHapticVibration);
+        hapticPulseCountdown = durationMilliseconds;
     }
 
     private void Awake()
@@ -54,8 +50,9 @@ public class VRTK_ControllerActions : MonoBehaviour {
 
         if (hapticPulseCountdown > 0)
         {
-            device.TriggerHapticPulse(hapticPulseStrength);
-            hapticPulseCountdown -= 1;
+            // 1000 microseconds = 1 millisecond
+            device.TriggerHapticPulse(1000);
+            hapticPulseCountdown -= Time.deltaTime * 1000;
         }
     }
 }


### PR DESCRIPTION
The first argument for device.TriggerHapticPulse is not strength, but
the duration of the pulse in microseconds.
This has been changed so ControllerActions.TriggerHapticPulse takes one
argument, the duration of the pulse in *milliseconds*.
There is not actually a haptic strength value in the OpenVR API. [See here.][1]

[1]:
https://github.com/ValveSoftware/openvr/wiki/IVRSystem::TriggerHapticPulse