### PR TITLE
feat(Interaction): add handle snap grab mechanic

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractGrab.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractGrab.cs
@@ -162,6 +162,16 @@ public class VRTK_InteractGrab : MonoBehaviour
             obj.transform.position = controllerAttachPoint.transform.position + obj.GetComponent<VRTK_InteractableObject>().snapToPosition;
         }
 
+        if (grabType == VRTK_InteractableObject.GrabSnapType.Handle_Snap && obj.GetComponent<VRTK_InteractableObject>().snapHandle != null)
+        {
+            // Identity Controller Rotation
+            this.transform.eulerAngles = new Vector3(0f, 270f, 0f);
+            obj.transform.eulerAngles = obj.GetComponent<VRTK_InteractableObject>().snapHandle.transform.localEulerAngles;
+
+            Vector3 snapHandleDelta = obj.GetComponent<VRTK_InteractableObject>().snapHandle.transform.position - obj.transform.position;
+            obj.transform.position = controllerAttachPoint.transform.position - snapHandleDelta;
+        }
+
         if (obj.GetComponent<VRTK_InteractableObject>().grabAttachMechanic == VRTK_InteractableObject.GrabAttachType.Child_Of_Controller)
         {
             SetControllerAsParent(obj);

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractableObject.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractableObject.cs
@@ -27,7 +27,8 @@ public class VRTK_InteractableObject : MonoBehaviour
     {
         Simple_Snap,
         Rotation_Snap,
-        Precision_Snap
+        Precision_Snap,
+        Handle_Snap
     }
 
     public enum GrabAttachType
@@ -49,6 +50,7 @@ public class VRTK_InteractableObject : MonoBehaviour
     public GrabSnapType grabSnapType = GrabSnapType.Simple_Snap;
     public Vector3 snapToRotation = Vector3.zero;
     public Vector3 snapToPosition = Vector3.zero;
+    public Transform snapHandle;
 
     [Header("Grab Mechanics", order = 3)]
     public GrabAttachType grabAttachMechanic = GrabAttachType.Fixed_Joint;

--- a/README.md
+++ b/README.md
@@ -658,6 +658,10 @@ The following script parameters are available:
    * `Precision_Snap` does not snap the object's position to the
    controller and picks the object up at the point the controller is
    touching the object (like a real life hand picking something up).
+   * `Handle_Snap` allows for an empty GameObject as a child of the
+   interactable object to be used as the reference snap point. On grab,
+   this empty GameObject rotation and position is used to orientate
+   the grabbed interactable object to the controller.
   * **Snap To Rotation:** A Vector3 of EulerAngles that determines the
   rotation of the object in relation to the controller on snap.
   This is useful for picking up guns or swords where the relative


### PR DESCRIPTION
The new `Handle Snap` grab mechanic allows you to specify a transform as
a child of the VRTK_InteractableObject to which the grab will snap. Any
rotation applied to the handle will rotate the object around the handle.