### PR TITLE
feat(Interaction): improve grabbable detection

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractGrab.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractGrab.cs
@@ -124,6 +124,7 @@ public class VRTK_InteractGrab : MonoBehaviour
         rb.useGravity = false;
         rb.mass = 100f;
         rb.collisionDetectionMode = CollisionDetectionMode.Continuous;
+        rb.constraints = RigidbodyConstraints.FreezeAll;
         ToggleRigidBody(false);
     }
 


### PR DESCRIPTION
This is a first independent part of a bigger change to support rigidbody based buttons. So far when enabling the rigidbody feature of the InteractGrab script it was checking for interactable objects. This is too broad. It should only check for grabbable objects. Also the rigidbody on the controller should freeze all constraints to eliminate strange side effects due to a spinning collider.