### PR TITLE
feat(Controller): add angle of touch on touchpad

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_ControllerEvents.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_ControllerEvents.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using System.Collections;
 
 public struct ControllerClickedEventArgs
@@ -6,6 +6,7 @@ public struct ControllerClickedEventArgs
     public uint controllerIndex;
     public float buttonPressure;
     public Vector2 touchpadAxis;
+    public float touchpadAngle;
 }
 
 public delegate void ControllerClickedEventHandler(object sender, ControllerClickedEventArgs e);
@@ -205,6 +206,14 @@ public class VRTK_ControllerEvents : MonoBehaviour {
         e.controllerIndex = controllerIndex;
         e.buttonPressure = buttonPressure;
         e.touchpadAxis = device.GetAxis();
+        
+        float angle = Mathf.Atan2( e.touchpadAxis.y, e.touchpadAxis.x ) * Mathf.Rad2Deg;
+        angle = 90.0f - angle;
+        if( angle < 0 )
+            angle += 360.0f;
+
+        e.touchpadAngle = angle;
+        
         return e;
     }
 


### PR DESCRIPTION
ControllerClickedEventArgs now contains touchpadAngle which is the angle in degrees of the touch on the touchpad around it's center, with 0 being up, 90 being right, 180 being down and 270 being left.