### PR TITLE
fix(InteractGrab): add support for kinematic objects

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractGrab.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractGrab.cs
@@ -163,6 +163,9 @@ namespace VRTK
 
         private void CreateJoint(GameObject obj)
         {
+            Rigidbody rb = obj.GetComponent<Rigidbody>();
+            if (rb) { rb.isKinematic = false; }
+
             if (obj.GetComponent<VRTK_InteractableObject>().grabAttachMechanic == VRTK_InteractableObject.GrabAttachType.Fixed_Joint)
             {
                 controllerAttachJoint = obj.AddComponent<FixedJoint>();

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractGrab.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractGrab.cs
@@ -210,8 +210,6 @@ namespace VRTK
         private Rigidbody ReleaseParentedObjectFromController()
         {
             var rigidbody = grabbedObject.GetComponent<Rigidbody>();
-            grabbedObject.transform.parent = null;
-            rigidbody.isKinematic = false;
             return rigidbody;
         }
 
@@ -252,12 +250,17 @@ namespace VRTK
         private void InitGrabbedObject()
         {
             grabbedObject = interactTouch.GetTouchedObject();
-            OnControllerGrabInteractableObject(interactTouch.SetControllerInteractEvent(grabbedObject));
-            grabbedObject.GetComponent<VRTK_InteractableObject>().Grabbed(this.gameObject);
-            grabbedObject.GetComponent<VRTK_InteractableObject>().ZeroVelocity();
             if (grabbedObject)
             {
-                grabbedObject.GetComponent<VRTK_InteractableObject>().ToggleHighlight(false);
+                var grabbedObjectScript = grabbedObject.GetComponent<VRTK_InteractableObject>();
+
+                OnControllerGrabInteractableObject(interactTouch.SetControllerInteractEvent(grabbedObject));
+
+                grabbedObjectScript.SaveCurrentState();
+                grabbedObjectScript.Grabbed(this.gameObject);
+                grabbedObjectScript.ZeroVelocity();
+
+                grabbedObjectScript.ToggleHighlight(false);
             }
             if (hideControllerOnGrab)
             {

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractableObject.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractableObject.cs
@@ -87,6 +87,9 @@ namespace VRTK
         private Transform trackPoint;
         private bool customTrackPoint = false;
 
+        private Transform previousParent;
+        private bool previousKinematicState;
+
         public virtual void OnInteractableObjectTouched(InteractableObjectEventArgs e)
         {
             if (InteractableObjectTouched != null)
@@ -171,6 +174,7 @@ namespace VRTK
             OnInteractableObjectUngrabbed(SetInteractableObjectEvent(previousGrabbingObject));
             RemoveTrackPoint();
             grabbingObject = null;
+            LoadPreviousState();
         }
 
         public virtual void StartUsing(GameObject usingObject)
@@ -251,6 +255,15 @@ namespace VRTK
             }
         }
 
+        public void SaveCurrentState()
+        {
+            if (grabbingObject == null)
+            {
+                previousParent = this.transform.parent;
+                previousKinematicState = rb.isKinematic;
+            }
+        }
+
         protected virtual void Awake()
         {
             rb = this.GetComponent<Rigidbody>();
@@ -280,6 +293,12 @@ namespace VRTK
         protected virtual void OnJointBreak(float force)
         {
             ForceReleaseGrab();
+        }
+
+        protected virtual void LoadPreviousState()
+        {
+            this.transform.parent = previousParent;
+            rb.isKinematic = previousKinematicState;
         }
 
         private void ForceReleaseGrab()


### PR DESCRIPTION
I noticed objects that were set to kinematic were not properly supported. I added a 'wasKinematic' variable that is set when an object is grabbed and then used to restore the state when the object is released.

Also, both types of grabs (SetControllerAsParent and CreateJoint) now explicitly set the kinematic state so they work properly when the object was originally set to kinematic.