### PR TITLE
fix(Interaction): save previous object state on grab

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractableObject.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractableObject.cs
@@ -87,6 +87,9 @@ namespace VRTK
         private Transform trackPoint;
         private bool customTrackPoint = false;
 
+        private Transform previousParent;
+        private bool previousKinematicState;
+
         public virtual void OnInteractableObjectTouched(InteractableObjectEventArgs e)
         {
             if (InteractableObjectTouched != null)
@@ -171,6 +174,7 @@ namespace VRTK
             OnInteractableObjectUngrabbed(SetInteractableObjectEvent(previousGrabbingObject));
             RemoveTrackPoint();
             grabbingObject = null;
+            LoadPreviousState();
         }
 
         public virtual void StartUsing(GameObject usingObject)
@@ -251,6 +255,20 @@ namespace VRTK
             }
         }
 
+        public void SaveCurrentState()
+        {
+            if (grabbingObject == null)
+            {
+                previousParent = this.transform.parent;
+                previousKinematicState = rb.isKinematic;
+            }
+        }
+
+        public void ToggleKinematic(bool state)
+        {
+            rb.isKinematic = state;
+        }
+
         protected virtual void Awake()
         {
             rb = this.GetComponent<Rigidbody>();
@@ -280,6 +298,12 @@ namespace VRTK
         protected virtual void OnJointBreak(float force)
         {
             ForceReleaseGrab();
+        }
+
+        protected virtual void LoadPreviousState()
+        {
+            this.transform.parent = previousParent;
+            rb.isKinematic = previousKinematicState;
         }
 
         private void ForceReleaseGrab()


### PR DESCRIPTION
The Interactable Object's previous parent and kinematic state is now
saved when the object is grabbed and reset back to it's original state
when it is no longed grabbed. Supports swapping hands without needing
to drop the item first.