### PR TITLE
fix(DeviceFinder): fix for compile waring in Unity 5.4+

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/Helper/DeviceFinder.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/Helper/DeviceFinder.cs
@@ -35,9 +35,10 @@
         public static Transform HeadsetTransform()
         {
 #if (UNITY_5_4_OR_NEWER)
-        return GameObject.FindObjectOfType<SteamVR_Camera>().GetComponent<Transform>();
-#endif
+            return GameObject.FindObjectOfType<SteamVR_Camera>().GetComponent<Transform>();
+#else
             return GameObject.FindObjectOfType<SteamVR_GameView>().GetComponent<Transform>();
+#endif
         }
     }
 }


### PR DESCRIPTION
Here's that commit for the compile warning separated out as requested.