### PR TITLE
fix(ControllerEvents): fix order of controller events

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_ControllerEvents.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_ControllerEvents.cs
@@ -304,28 +304,6 @@
             Vector2 currentTriggerAxis = device.GetAxis(Valve.VR.EVRButtonId.k_EButton_SteamVR_Trigger);
             Vector2 currentTouchpadAxis = device.GetAxis();
 
-            if (Vector2ShallowEquals(triggerAxis, currentTriggerAxis))
-            {
-                triggerAxisChanged = false;
-            }
-            else
-            {
-                OnTriggerAxisChanged(SetButtonEvent(ref triggerAxisChanged, true, currentTriggerAxis.x));
-            }
-
-            if (Vector2ShallowEquals(touchpadAxis, currentTouchpadAxis))
-            {
-                touchpadAxisChanged = false;
-            }
-            else
-            {
-                OnTouchpadAxisChanged(SetButtonEvent(ref touchpadTouched, true, 1f));
-                touchpadAxisChanged = true;
-            }
-
-            touchpadAxis = new Vector2(currentTouchpadAxis.x, currentTouchpadAxis.y);
-            triggerAxis = new Vector2(currentTriggerAxis.x, currentTriggerAxis.y);
-
             //Trigger
             if (device.GetTouchDown(SteamVR_Controller.ButtonMask.Trigger))
             {
@@ -336,6 +314,17 @@
             {
                 OnTriggerReleased(SetButtonEvent(ref triggerPressed, false, 0f));
                 EmitAlias(ButtonAlias.Trigger, false, 0f, ref triggerPressed);
+            }
+            else
+            {
+                if (Vector2ShallowEquals(triggerAxis, currentTriggerAxis))
+                {
+                    triggerAxisChanged = false;
+                }
+                else
+                {
+                    OnTriggerAxisChanged(SetButtonEvent(ref triggerAxisChanged, true, currentTriggerAxis.x));
+                }
             }
 
             //ApplicationMenu
@@ -386,6 +375,21 @@
                 OnTouchpadTouchEnd(SetButtonEvent(ref touchpadTouched, false, 0f));
                 EmitAlias(ButtonAlias.Touchpad_Touch, false, 0f, ref touchpadTouched);
             }
+            else
+            {
+                if (Vector2ShallowEquals(touchpadAxis, currentTouchpadAxis))
+                {
+                    touchpadAxisChanged = false;
+                }
+                else {
+                    OnTouchpadAxisChanged(SetButtonEvent(ref touchpadTouched, true, 1f));
+                    touchpadAxisChanged = true;
+                }
+            }
+
+            // Save current touch and trigger settings to detect next change.
+            touchpadAxis = new Vector2(currentTouchpadAxis.x, currentTouchpadAxis.y);
+            triggerAxis = new Vector2(currentTriggerAxis.x, currentTriggerAxis.y);
         }
     }
 }


### PR DESCRIPTION
Solves an issue where `TouchpadAxisChanged` occurred before `TouchpadTouchStart` and `TriggerAxisChanged` occurred before `TriggerPressed`. Now, these can only occur in the following frame if the value continues to change, so now you can be assured that a 'Start' event will occur before a 'Changed' event for initialization purposes. (I needed this to get the first change delta and start tracking changes at the right moment.)

This also keeps the 'Changed' events from happening on the 'End' event frame, which would often cause a value jump. (At least they would with my tests on `TouchpadAxisChanged`.)