### PR TITLE
feat(Interaction): add RequireComponents to grab and touch

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractGrab.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractGrab.cs
@@ -16,6 +16,7 @@ namespace VRTK
     using UnityEngine;
     using System.Collections;
 
+    [RequireComponent(typeof(VRTK_InteractTouch)), RequireComponent(typeof(VRTK_ControllerEvents))]
     public class VRTK_InteractGrab : MonoBehaviour
     {
         public Rigidbody controllerAttachPoint = null;

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractTouch.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractTouch.cs
@@ -18,6 +18,7 @@ namespace VRTK
 
     public delegate void ObjectInteractEventHandler(object sender, ObjectInteractEventArgs e);
 
+    [RequireComponent(typeof(VRTK_ControllerActions))]
     public class VRTK_InteractTouch : MonoBehaviour
     {
 


### PR DESCRIPTION
Since `InteractGrab` and `InteractTouch` don't work unless certain
components are a part of the controller, the `RequireComponent`
attributes will make sure those components are there or automatically
add them. They also keep required components from being removed in
the Unity editor.