### PR TITLE
feat(InteractableObject): add a rigid body if missing

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractableObject.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractableObject.cs
@@ -254,6 +254,13 @@ namespace VRTK
         protected virtual void Awake()
         {
             rb = this.GetComponent<Rigidbody>();
+
+            // If there is no rigid body, add one and set it to 'kinematic'.
+            if (!rb)
+            {
+                rb = gameObject.AddComponent<Rigidbody>();
+                rb.isKinematic = true;
+            }
         }
 
         protected virtual void Start()


### PR DESCRIPTION
If no rigid body is found when `InteractableObject` starts up, it will
add one, but make sure the rigid body is set to 'kinematic' so it
doesn't start unexpectedly rolling around, popping up, or falling.