### PR TITLE
fix(Sword): update to #ifs to support Unity 5.1

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Examples/Resources/Scripts/Sword.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Examples/Resources/Scripts/Sword.cs
@@ -29,7 +29,11 @@ public class Sword : VRTK_InteractableObject
     {
         if (controllerActions && IsGrabbed())
         {
+#if UNITY_5_3_OR_NEWER
             collisionForce = collision.impulse.magnitude * impactMagnifier;
+#else
+            collisionForce = collision.relativeVelocity.magnitude*impactMagnifier;
+#endif
             controllerActions.TriggerHapticPulse(40, (ushort)collisionForce);
         }
     }


### PR DESCRIPTION
Unity 5.1 doesn't have support for 'collision.impulse', so we use
'collision.relativeVelocity' instead.