### PR TITLE
Fixed teleporting code.

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_HeightAdjustTeleport.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_HeightAdjustTeleport.cs
@@ -26,7 +26,7 @@ namespace VRTK
             adjustYForTerrain = true;
         }
 
-        protected override void DoTeleport(object sender, DestinationMarkerEventArgs e)
+        public override void DoTeleport(object sender, DestinationMarkerEventArgs e)
         {
             base.DoTeleport(sender, e);
             if (e.enableTeleport)
@@ -44,7 +44,7 @@ namespace VRTK
 
         private float GetTeleportY(Transform target, Vector3 tipPosition)
         {
-            float newY = this.transform.position.y;
+            float newY = reference.position.y;
             //Check to see if the tip is on top of an object
             if (target && (tipPosition.y + 0.5f) > (target.position.y + (target.localScale.y / 2)))
             {
@@ -71,7 +71,7 @@ namespace VRTK
 
         private void DropToNearestFloor(bool withBlink)
         {
-            if (enableTeleport && eyeCamera.transform.position.y > this.transform.position.y)
+            if (enableTeleport && eyeCamera.transform.position.y > reference.position.y)
             {
                 //send a ray down to find the closest object to stand on
                 Ray ray = new Ray(eyeCamera.transform.position, -transform.up);
@@ -89,7 +89,7 @@ namespace VRTK
                         Blink(blinkTransitionSpeed);
                     }
 
-                    Vector3 newPosition = new Vector3(this.transform.position.x, floorY, this.transform.position.z);
+                    Vector3 newPosition = new Vector3(reference.position.x, floorY, reference.position.z);
                     var teleportArgs = new DestinationMarkerEventArgs
                     {
                         destinationPosition = newPosition,


### PR DESCRIPTION
I found bugs when the teleporting code tries to locate the controllers,
but fails in some instances like if the controller is turned on after
game starts.  I add a teleport object to each controller as they start
up and register for teleport event.

These changes also work fine with the camerarig prefab from Steam.  I programatically add the pointers to the controllers.

I have a script that first 

I have a script added to a game object which sets stuff up.  For starters.

    void Start()
    {
        // add 
        SteamVR_ControllerManager controllerMgr = FindObjectOfType<SteamVR_ControllerManager>();

        // add pointers to controllers
        controllerMgr.left.gameObject.AddComponent<VRRS_Pointer>();
        controllerMgr.right.gameObject.AddComponent<VRRS_Pointer>();
    }

// inside VRRS_Pointer.cs
  void Awake()
    {
        trackedObj = GetComponent<SteamVR_TrackedObject>();
        VRTK_SimplePointer pointer = gameObject.AddComponent<VRTK_SimplePointer>();

        // add the teleport to the main camera rig
        teleport = gameObject.AddComponent<VRTK_HeightAdjustTeleport>();
        teleport.playSpaceFalling = false;  // causes jumpiness
        teleport.ignoreTargetWithTagOrClass = ignoreTargetWithTagOrClass;

        // listen for teleport events
        pointer.DestinationMarkerSet += new DestinationMarkerEventHandler(DoTeleport);
        pointer.SetInvalidTarget(ignoreTargetWithTagOrClass);
    }

    private void DoTeleport(object sender, DestinationMarkerEventArgs e)
    {
        teleport.DoTeleport(sender, e);
    }

Anyway, these changes fix bugs I was seeing. I like to build things programatically in the scene and I was seeing failures, so I made these changes.  Let me know if you have questions.