### PR TITLE
feat(Controller): add ability to get controller velocity

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Examples/Resources/Scripts/Breakable_Cube.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Examples/Resources/Scripts/Breakable_Cube.cs
@@ -2,38 +2,55 @@
 using System.Collections;
 
 public class Breakable_Cube : MonoBehaviour {
-    float breakForce = 150f;
+    private float breakForce = 150f;
 
-    void Start()
+    private void Start()
     {
         this.GetComponent<Rigidbody>().collisionDetectionMode = CollisionDetectionMode.Continuous;
     }
 
-    void OnCollisionEnter(Collision collision)
+    private void OnCollisionEnter(Collision collision)
     {
-        if((collision.collider.name.Contains("Sword") && collision.collider.GetComponent<Sword>().CollisionForce() > breakForce) || collision.collider.name.Contains("Arrow"))
+        var collisionForce = GetCollisionForce(collision);
+
+        if(collisionForce > 0)
         {
-            ExplodeCube();
+            ExplodeCube(collisionForce);
         }
     }
 
-    void ExplodeCube()
+    private float GetCollisionForce(Collision collision)
+    {
+        if ((collision.collider.name.Contains("Sword") && collision.collider.GetComponent<Sword>().CollisionForce() > breakForce))
+        {
+            return collision.collider.GetComponent<Sword>().CollisionForce() * 1.2f;
+        }
+
+        if (collision.collider.name.Contains("Arrow"))
+        {
+            return 500f;
+        }
+
+        return 0f;
+    }
+
+    private void ExplodeCube(float force)
     {
         foreach (Transform face in this.GetComponentsInChildren<Transform>())
         {
             if (face.transform.name == this.transform.name) continue;
-            ExplodeFace(face);
+            ExplodeFace(face, force);
         }
         Destroy(this.gameObject, 10f);
     }
 
-    void ExplodeFace(Transform face)
+    private void ExplodeFace(Transform face, float force)
     {
         face.transform.parent = null;
         Rigidbody rb = face.gameObject.AddComponent<Rigidbody>();
         rb.isKinematic = false;
         rb.useGravity = true;
-        rb.AddExplosionForce(750f, Vector3.zero, 0f);
+        rb.AddExplosionForce(force, Vector3.zero, 0f);
         Destroy(face.gameObject, 10f);
     }
 }

--- a/Assets/SteamVR_Unity_Toolkit/Examples/Resources/Scripts/Sword.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Examples/Resources/Scripts/Sword.cs
@@ -4,9 +4,10 @@ using VRTK;
 
 public class Sword : VRTK_InteractableObject
 {
-    VRTK_ControllerActions controllerActions;
-    float impactMagnifier = 200f;
-    float collisionForce = 0f;
+    private VRTK_ControllerActions controllerActions;
+    private VRTK_ControllerEvents controllerEvents;
+    private float impactMagnifier = 120f;
+    private float collisionForce = 0f;
 
     public float CollisionForce()
     {
@@ -17,6 +18,7 @@ public class Sword : VRTK_InteractableObject
     {
         base.Grabbed(grabbingObject);
         controllerActions = grabbingObject.GetComponent<VRTK_ControllerActions>();
+        controllerEvents = grabbingObject.GetComponent<VRTK_ControllerEvents>();
     }
 
     protected override void Awake()
@@ -27,10 +29,13 @@ public class Sword : VRTK_InteractableObject
 
     private void OnCollisionEnter(Collision collision)
     {
-        if (controllerActions && IsGrabbed())
+        if (controllerActions && controllerEvents && IsGrabbed())
         {
-            collisionForce = collision.impulse.magnitude * impactMagnifier;
+            collisionForce = controllerEvents.GetVelocity().magnitude * impactMagnifier;
             controllerActions.TriggerHapticPulse((ushort)collisionForce, 0.5f, 0.01f);
+        } else
+        {
+            collisionForce = collision.relativeVelocity.magnitude * impactMagnifier;
         }
     }
 }

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_ControllerEvents.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_ControllerEvents.cs
@@ -82,6 +82,9 @@
         private Vector2 touchpadAxis = Vector2.zero;
         private Vector2 triggerAxis = Vector2.zero;
 
+        private Vector3 controllerVelocity = Vector3.zero;
+        private Vector3 controllerAngularVelocity = Vector3.zero;
+
         public virtual void OnTriggerPressed(ControllerInteractionEventArgs e)
         {
             if (TriggerPressed != null)
@@ -202,7 +205,19 @@
                 AliasMenuOff(this, e);
         }
 
-        ControllerInteractionEventArgs SetButtonEvent(ref bool buttonBool, bool value, float buttonPressure)
+        public Vector3 GetVelocity()
+        {
+            SetVelocity();
+            return controllerVelocity;
+        }
+
+        public Vector3 GetAngularVelocity()
+        {
+            SetVelocity();
+            return controllerAngularVelocity;
+        }
+
+        private ControllerInteractionEventArgs SetButtonEvent(ref bool buttonBool, bool value, float buttonPressure)
         {
             buttonBool = value;
             ControllerInteractionEventArgs e;
@@ -220,18 +235,18 @@
             return e;
         }
 
-        void Awake()
+        private void Awake()
         {
             trackedController = GetComponent<SteamVR_TrackedObject>();
         }
 
-        void Start()
+        private void Start()
         {
             controllerIndex = (uint)trackedController.index;
             device = SteamVR_Controller.Input((int)controllerIndex);
         }
 
-        void EmitAlias(ButtonAlias type, bool touchDown, float buttonPressure, ref bool buttonBool)
+        private void EmitAlias(ButtonAlias type, bool touchDown, float buttonPressure, ref bool buttonBool)
         {
             if (pointerToggleButton == type)
             {
@@ -290,13 +305,13 @@
             }
         }
 
-        bool Vector2ShallowEquals(Vector2 vectorA, Vector2 vectorB)
+        private bool Vector2ShallowEquals(Vector2 vectorA, Vector2 vectorB)
         {
             return (vectorA.x.ToString("F" + axisFidelity) == vectorB.x.ToString("F" + axisFidelity) &&
                     vectorA.y.ToString("F" + axisFidelity) == vectorB.y.ToString("F" + axisFidelity));
         }
 
-        void Update()
+        private void Update()
         {
             controllerIndex = (uint)trackedController.index;
             device = SteamVR_Controller.Input((int)controllerIndex);
@@ -390,6 +405,21 @@
             // Save current touch and trigger settings to detect next change.
             touchpadAxis = new Vector2(currentTouchpadAxis.x, currentTouchpadAxis.y);
             triggerAxis = new Vector2(currentTriggerAxis.x, currentTriggerAxis.y);
+        }
+
+        private void SetVelocity()
+        {
+            var origin = trackedController.origin ? trackedController.origin : trackedController.transform.parent;
+            if (origin != null)
+            {
+                controllerVelocity = origin.TransformDirection(device.velocity);
+                controllerAngularVelocity = origin.TransformDirection(device.angularVelocity);
+            }
+            else
+            {
+                controllerVelocity = device.velocity;
+                controllerAngularVelocity = device.angularVelocity;
+            }
         }
     }
 }


### PR DESCRIPTION
The Controller Events now has a method for getting the current velocity
and angular velocity of the controller.

The sword example has been updated to utilise this new velocity to
determine how fast the sword is being swung to determine the collision
force.