### PR TITLE
Fix(interaction) precise spring anchor

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractGrab.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractGrab.cs
@@ -168,6 +168,10 @@ namespace VRTK
                 SpringJoint tempSpringJoint = obj.AddComponent<SpringJoint>();
                 tempSpringJoint.spring = objectScript.springJointStrength;
                 tempSpringJoint.damper = objectScript.springJointDamper;
+                if(objectScript.grabAttachMechanic == VRTK_InteractableObject.GrabSnapType.Precision_Snap)
+                {
+                    tempSpringJoint.anchor = obj.transform.InverseTransformPoint(controllerAttachPoint.position);
+                }
                 controllerAttachJoint = tempSpringJoint;
             }
             controllerAttachJoint.breakForce = objectScript.detachThreshold;


### PR DESCRIPTION
Using the Precision Snap grab mode with a Spring Joint was producing unintuitive effects, as the Spring Joint was always anchored at the grabbed object's center point. This will set the anchor point for a temporary Spring Joint when Precision Snap is in use.