### PR TITLE
feat(Interaction): add haptic feedback coroutine

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Examples/Resources/Scripts/Archery/BowAim.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Examples/Resources/Scripts/Archery/BowAim.cs
@@ -169,8 +169,8 @@ public class BowAim : MonoBehaviour {
 
         if (!currentPull.ToString("F2").Equals(previousPull.ToString("F2")))
         {
-            holdActions.TriggerHapticPulse(1, (ushort)bowVibration);
-            stringActions.TriggerHapticPulse(1, (ushort)stringVibration);
+            holdActions.TriggerHapticPulse((ushort)bowVibration);
+            stringActions.TriggerHapticPulse((ushort)stringVibration);
         }
         previousPull = currentPull;
     }

--- a/Assets/SteamVR_Unity_Toolkit/Examples/Resources/Scripts/Sword.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Examples/Resources/Scripts/Sword.cs
@@ -30,7 +30,7 @@ public class Sword : VRTK_InteractableObject
         if (controllerActions && IsGrabbed())
         {
             collisionForce = collision.impulse.magnitude * impactMagnifier;
-            controllerActions.TriggerHapticPulse(40, (ushort)collisionForce);
+            controllerActions.TriggerHapticPulse((ushort)collisionForce, 0.5f, 0.01f);
         }
     }
 }

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_ControllerActions.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_ControllerActions.cs
@@ -7,7 +7,6 @@
     {
         private bool controllerVisible = true;
         private ushort hapticPulseStrength;
-        private int hapticPulseCountdown;
 
         private uint controllerIndex;
         private SteamVR_TrackedObject trackedController;
@@ -39,10 +38,16 @@
             controllerVisible = on;
         }
 
-        public void TriggerHapticPulse(int duration, ushort strength)
+        public void TriggerHapticPulse(ushort strength)
         {
-            hapticPulseCountdown = duration;
             hapticPulseStrength = (strength <= maxHapticVibration ? strength : maxHapticVibration);
+            device.TriggerHapticPulse(hapticPulseStrength);
+        }
+
+        public void TriggerHapticPulse(ushort strength, float duration, float pulseInterval)
+        {
+            hapticPulseStrength = (strength <= maxHapticVibration ? strength : maxHapticVibration);
+            StartCoroutine(Pulse(duration, hapticPulseStrength, pulseInterval));
         }
 
         private void Awake()
@@ -54,11 +59,20 @@
         {
             controllerIndex = (uint)trackedController.index;
             device = SteamVR_Controller.Input((int)controllerIndex);
+        }
 
-            if (hapticPulseCountdown > 0)
+        private IEnumerator Pulse(float duration, int hapticPulseStrength, float pulseInterval)
+        {
+            if (pulseInterval <= 0)
             {
-                device.TriggerHapticPulse(hapticPulseStrength);
-                hapticPulseCountdown -= 1;
+                yield break;
+            }
+
+            while (duration > 0)
+            {
+                device.TriggerHapticPulse((ushort)hapticPulseStrength);
+                yield return new WaitForSeconds(pulseInterval);
+                duration -= pulseInterval;
             }
         }
     }

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractGrab.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractGrab.cs
@@ -351,7 +351,7 @@ namespace VRTK
                     var rumbleAmount = grabbedObject.GetComponent<VRTK_InteractableObject>().rumbleOnGrab;
                     if (!rumbleAmount.Equals(Vector2.zero))
                     {
-                        controllerActions.TriggerHapticPulse((int)rumbleAmount.x, (ushort)rumbleAmount.y);
+                        controllerActions.TriggerHapticPulse((ushort)rumbleAmount.y, (int)rumbleAmount.x, 0.05f);
                     }
                 }
             }

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractTouch.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractTouch.cs
@@ -127,7 +127,7 @@ namespace VRTK
                 var rumbleAmount = touchedObject.GetComponent<VRTK_InteractableObject>().rumbleOnTouch;
                 if (!rumbleAmount.Equals(Vector2.zero))
                 {
-                    controllerActions.TriggerHapticPulse((int)rumbleAmount.x, (ushort)rumbleAmount.y);
+                    controllerActions.TriggerHapticPulse((ushort)rumbleAmount.y, (int)rumbleAmount.x, 0.05f);
                 }
             }
         }

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractUse.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractUse.cs
@@ -112,7 +112,7 @@ namespace VRTK
                 var rumbleAmount = usingObject.GetComponent<VRTK_InteractableObject>().rumbleOnUse;
                 if (!rumbleAmount.Equals(Vector2.zero))
                 {
-                    controllerActions.TriggerHapticPulse((int)rumbleAmount.x, (ushort)rumbleAmount.y);
+                    controllerActions.TriggerHapticPulse((ushort)rumbleAmount.y, (int)rumbleAmount.x, 0.05f);
                 }
             }
         }


### PR DESCRIPTION
Changes the TriggerHapticPulse method to call a coroutine rather than
performing the haptic feedback event in the update method. This allows
feedback events specified in time intervals, rather than number of
frames. There are now two TriggerHapticPulse methods.
TriggerHapticPulse(ushort strength) does not call a coroutine, and
simply triggers a single pulse of specified strength.
TriggerHapticPulse(ushort strength, float duration, float pulseInterval)
allows specification of strength, total pulse duration, and the interval
that the controller should pulse at for that duration.