### PR TITLE
feat(Interaction): add option to prevent certain controller interaction

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/Helper/DeviceFinder.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/Helper/DeviceFinder.cs
@@ -7,6 +7,13 @@
 
     public class DeviceFinder : MonoBehaviour
     {
+        public enum ControllerHand
+        {
+            None,
+            Left,
+            Right
+        }
+
         //Seconds to keep trying to initialise
         public static float initTries = 15f;
 
@@ -30,6 +37,36 @@
                 }
             }
             return null;
+        }
+
+        public static ControllerHand GetControllerHandType(string hand)
+        {
+            switch(hand.ToLower())
+            {
+                case "left":
+                    return ControllerHand.Left;
+                case "right":
+                    return ControllerHand.Right;
+                default:
+                    return ControllerHand.None;
+            }
+        }
+
+        public static bool IsControllerOfHand(GameObject checkController, ControllerHand hand)
+        {
+            var controllerManager = GameObject.FindObjectOfType<SteamVR_ControllerManager>();
+
+            if (hand == ControllerHand.Left && controllerManager && controllerManager.left == checkController)
+            {
+                return true;
+            }
+
+            if (hand == ControllerHand.Right && controllerManager && controllerManager.right == checkController)
+            {
+                return true;
+            }
+
+            return false;
         }
 
         public static Transform HeadsetTransform()

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractGrab.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractGrab.cs
@@ -235,7 +235,10 @@ namespace VRTK
             if (controllerAttachJoint == null && grabbedObject == null && IsObjectGrabbable(interactTouch.GetTouchedObject()))
             {
                 InitGrabbedObject();
-                SnapObjectToGrabToController(grabbedObject);
+                if(grabbedObject)
+                {
+                    SnapObjectToGrabToController(grabbedObject);
+                }
             }
         }
 
@@ -253,6 +256,12 @@ namespace VRTK
             if (grabbedObject)
             {
                 var grabbedObjectScript = grabbedObject.GetComponent<VRTK_InteractableObject>();
+
+                if (!grabbedObjectScript.IsValidInteractableController(this.gameObject, grabbedObjectScript.allowedGrabControllers))
+                {
+                    grabbedObject = null;
+                    return;
+                }
 
                 OnControllerGrabInteractableObject(interactTouch.SetControllerInteractEvent(grabbedObject));
 

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractTouch.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractTouch.cs
@@ -115,16 +115,24 @@ namespace VRTK
                     touchedObject = collider.gameObject.GetComponentInParent<VRTK_InteractableObject>().gameObject;
                 }
 
+                var touchedObjectScript = touchedObject.GetComponent<VRTK_InteractableObject>();
+
+                if(! touchedObjectScript.IsValidInteractableController(this.gameObject, touchedObjectScript.allowedTouchControllers))
+                {
+                    touchedObject = null;
+                    return;
+                }
+
                 OnControllerTouchInteractableObject(SetControllerInteractEvent(touchedObject));
-                touchedObject.GetComponent<VRTK_InteractableObject>().ToggleHighlight(true, globalTouchHighlightColor);
-                touchedObject.GetComponent<VRTK_InteractableObject>().StartTouching(this.gameObject);
+                touchedObjectScript.ToggleHighlight(true, globalTouchHighlightColor);
+                touchedObjectScript.StartTouching(this.gameObject);
 
                 if (controllerActions.IsControllerVisible() && hideControllerOnTouch)
                 {
                     Invoke("HideController", hideControllerDelay);
                 }
 
-                var rumbleAmount = touchedObject.GetComponent<VRTK_InteractableObject>().rumbleOnTouch;
+                var rumbleAmount = touchedObjectScript.rumbleOnTouch;
                 if (!rumbleAmount.Equals(Vector2.zero))
                 {
                     controllerActions.TriggerHapticPulse((ushort)rumbleAmount.y, (int)rumbleAmount.x, 0.05f);
@@ -134,6 +142,11 @@ namespace VRTK
 
         private void OnTriggerExit(Collider collider)
         {
+            if (touchedObject == null)
+            {
+                return;
+            }
+
             if (IsObjectInteractable(collider.gameObject))
             {
                 GameObject untouched;

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractUse.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractUse.cs
@@ -101,15 +101,25 @@ namespace VRTK
             if ((usingObject == null || usingObject != touchedObject) && IsObjectUsable(touchedObject))
             {
                 usingObject = touchedObject;
+                var usingObjectScript = usingObject.GetComponent<VRTK_InteractableObject>();
+
+                if (!usingObjectScript.IsValidInteractableController(this.gameObject, usingObjectScript.allowedUseControllers))
+                {
+                    usingObject = null;
+                    return;
+                }
+
                 OnControllerUseInteractableObject(interactTouch.SetControllerInteractEvent(usingObject));
-                usingObject.GetComponent<VRTK_InteractableObject>().StartUsing(this.gameObject);
+                usingObjectScript.StartUsing(this.gameObject);
+
                 if (hideControllerOnUse)
                 {
                     Invoke("HideController", hideControllerDelay);
                 }
-                usingObject.GetComponent<VRTK_InteractableObject>().ToggleHighlight(false);
 
-                var rumbleAmount = usingObject.GetComponent<VRTK_InteractableObject>().rumbleOnUse;
+                usingObjectScript.ToggleHighlight(false);
+
+                var rumbleAmount = usingObjectScript.rumbleOnUse;
                 if (!rumbleAmount.Equals(Vector2.zero))
                 {
                     controllerActions.TriggerHapticPulse((ushort)rumbleAmount.y, (int)rumbleAmount.x, 0.05f);
@@ -146,7 +156,7 @@ namespace VRTK
             if (touchedObject != null && interactTouch.IsObjectInteractable(touchedObject))
             {
                 UseInteractedObject(touchedObject);
-                if (!IsObjectHoldOnUse(usingObject))
+                if (usingObject && !IsObjectHoldOnUse(usingObject))
                 {
                     SetObjectUsingState(usingObject, GetObjectUsingState(usingObject) + 1);
                 }

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractableObject.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractableObject.cs
@@ -40,10 +40,18 @@ namespace VRTK
             Child_Of_Controller
         }
 
+        public enum AllowedController
+        {
+            Both,
+            Left_Only,
+            Right_Only
+        }
+
         [Header("Touch Interactions", order = 1)]
         public bool highlightOnTouch = false;
         public Color touchHighlightColor = Color.clear;
         public Vector2 rumbleOnTouch = Vector2.zero;
+        public AllowedController allowedTouchControllers = AllowedController.Both;
 
         [Header("Grab Interactions", order = 2)]
         public bool isGrabbable = false;
@@ -55,6 +63,7 @@ namespace VRTK
         public Vector3 snapToPosition = Vector3.zero;
         public Transform snapHandle;
         public Vector2 rumbleOnGrab = Vector2.zero;
+        public AllowedController allowedGrabControllers = AllowedController.Both;
 
         [Header("Grab Mechanics", order = 3)]
         public GrabAttachType grabAttachMechanic = GrabAttachType.Fixed_Joint;
@@ -68,6 +77,7 @@ namespace VRTK
         public bool holdButtonToUse = true;
         public bool pointerActivatesUseAction = false;
         public Vector2 rumbleOnUse = Vector2.zero;
+        public AllowedController allowedUseControllers = AllowedController.Both;
 
         public event InteractableObjectEventHandler InteractableObjectTouched;
         public event InteractableObjectEventHandler InteractableObjectUntouched;
@@ -272,6 +282,17 @@ namespace VRTK
         public GameObject GetGrabbingObject()
         {
             return grabbingObject;
+        }
+
+        public bool IsValidInteractableController(GameObject actualController, AllowedController controllerCheck)
+        {
+            if (controllerCheck == AllowedController.Both)
+            {
+                return true;
+            }
+
+            var controllerHand = DeviceFinder.GetControllerHandType(controllerCheck.ToString().Replace("_Only", ""));
+            return (DeviceFinder.IsControllerOfHand(actualController, controllerHand));
         }
 
         protected virtual void Awake()

--- a/README.md
+++ b/README.md
@@ -659,6 +659,12 @@ The following script parameters are available:
   be triggered upon touching the object, the `x` denotes the length
   of time, the `y` denotes the strength of the pulse. (x and y will
   be replaced in the future with a custom editor)
+  * **Allowed Touch Controllers:** Determines which controller can
+  initiate a touch action. The options available are:
+   * `Both` means both controllers will register a touch
+   * `Left_Only` means only the left controller will register a touch
+   * `Right_Only` means only the right controller will register a touch
+
 
 ######Grab Interactions
   * **Is Grabbable:** Determines if the object can be grabbed
@@ -704,6 +710,11 @@ The following script parameters are available:
   be triggered upon grabbing the object, the `x` denotes the length
   of time, the `y` denotes the strength of the pulse. (x and y will
   be replaced in the future with a custom editor)
+  * **Allowed Grab Controllers:** Determines which controller can
+  initiate a grab action. The options available are:
+   * `Both` means both controllers are allowed to grab
+   * `Left_Only` means only the left controller is allowed to grab
+   * `Right_Only` means only the right controller is allowed to grab
 
 ######Grab Mechanics
   * **Grab Attach Type:** This determines how the grabbed item will
@@ -766,6 +777,11 @@ The following script parameters are available:
   be triggered upon using the object, the `x` denotes the length
   of time, the `y` denotes the strength of the pulse. (x and y will
   be replaced in the future with a custom editor)
+  * **Allowed Use Controllers:** Determines which controller can
+  initiate a use action. The options available are:
+   * `Both` means both controllers are allowed to use
+   * `Left_Only` means only the left controller is allowed to use
+   * `Right_Only` means only the right controller is allowed to use
 
 The following events are emitted:
 


### PR DESCRIPTION
It is now possible to limit the interaction on an object to a specific
controller. The new parameters available on the Interactable Object:

  * Allowed Touch Controllers
  * Allowed Grab Controllers
  * Allowed Use Controllers

Each option can be selected as:

  * Both
  * Left_Only
  * Right_Only

If the option isn't `Both` then only the selected controller will
perform the relevant interaction.