### PR TITLE
feat(Interaction): prevent object swapping between controllers

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractableObject.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractableObject.cs
@@ -56,6 +56,7 @@ namespace VRTK
         [Header("Grab Interactions", order = 2)]
         public bool isGrabbable = false;
         public bool isDroppable = true;
+        public bool isSwappable = true;
         public bool holdButtonToGrab = true;
         public float onGrabCollisionDelay = 0f;
         public GrabSnapType grabSnapType = GrabSnapType.Simple_Snap;
@@ -99,6 +100,7 @@ namespace VRTK
 
         private Transform previousParent;
         private bool previousKinematicState;
+        private bool previousIsGrabbable;
 
         public virtual void OnInteractableObjectTouched(InteractableObjectEventArgs e)
         {
@@ -177,6 +179,11 @@ namespace VRTK
             RemoveTrackPoint();
             grabbingObject = currentGrabbingObject;
             SetTrackPoint(grabbingObject);
+            if (! isSwappable)
+            {
+                previousIsGrabbable = isGrabbable;
+                isGrabbable = false;
+            }
         }
 
         public virtual void Ungrabbed(GameObject previousGrabbingObject)
@@ -337,6 +344,10 @@ namespace VRTK
         {
             this.transform.parent = previousParent;
             rb.isKinematic = previousKinematicState;
+            if (! isSwappable)
+            {
+                isGrabbable = previousIsGrabbable;
+            }
         }
 
         private void ForceReleaseGrab()

--- a/README.md
+++ b/README.md
@@ -692,6 +692,10 @@ The following script parameters are available:
   if the Grab Attach Mechanic is a joint and too much force is applied
   to the object and the joint is broken. To prevent this it's better
   to use the Child Of Controller mechanic.
+  * **Is Swappable:** Determines if the object can be swapped between
+  controllers when it is picked up. If it is unchecked then the
+  object must be dropped before it can be picked up by the other
+  controller.
   * **Hold Button To Grab:** If this is checked then the grab button
   on the controller needs to be continually held down to keep grabbing.
   If this is unchecked the grab button toggles the grab action with


### PR DESCRIPTION
It is now possible set the `Is Swappable` parameter on an Interactable
Object and if it is set to false then the object cannot be swapped
between hands and must be dropped before the other controller can
grab it.