### PR TITLE
fix(Pointer): prevent pointer events when script is disabled

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
@@ -120,7 +120,7 @@ namespace VRTK
 
         protected virtual void EnablePointerBeam(object sender, ControllerInteractionEventArgs e)
         {
-            if (!isActive && activateDelayTimer <= 0)
+            if (this.enabled && !isActive && activateDelayTimer <= 0)
             {
                 setPlayAreaCursorCollision(false);
                 controllerIndex = e.controllerIndex;
@@ -142,7 +142,7 @@ namespace VRTK
 
         protected virtual void PointerIn()
         {
-            if (!pointerContactTarget)
+            if (!this.enabled || !pointerContactTarget)
             {
                 return;
             }
@@ -158,7 +158,7 @@ namespace VRTK
 
         protected virtual void PointerOut()
         {
-            if (!pointerContactTarget)
+            if (!this.enabled || !pointerContactTarget)
             {
                 return;
             }
@@ -174,7 +174,7 @@ namespace VRTK
 
         protected virtual void PointerSet()
         {
-            if (!isActive || !pointerContactTarget)
+            if (!this.enabled || !isActive || !pointerContactTarget)
             {
                 return;
             }

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_BasicTeleport.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_BasicTeleport.cs
@@ -50,8 +50,7 @@ namespace VRTK
         {
             if (markerMaker)
             {
-                var worldMarker = markerMaker.GetComponent<VRTK_DestinationMarker>();
-                if (worldMarker)
+                foreach(var worldMarker in markerMaker.GetComponents<VRTK_DestinationMarker>())
                 {
                     worldMarker.DestinationMarkerSet += new DestinationMarkerEventHandler(DoTeleport);
                     worldMarker.SetInvalidTarget(ignoreTargetWithTagOrClass);


### PR DESCRIPTION
The pointer script would still throw the relevant events even if the
script component had been disabled at run time because the events had
already been set up. The fix is to check if the script is enabled and
only emit the events if it is.

The Basic Teleport has also been updated to find all Destination
Markers on an object and not just the first one so it's possible to
include multiple pointers on the same object and toggle them at
runtime.