### PR TITLE
refactor(identification): determine player objects with script

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
@@ -78,7 +78,7 @@ namespace VRTK
                 return;
             }
 
-            this.name = "PlayerObject_" + this.name;
+            Utilities.SetPlayerObject(this.gameObject, VRTK_PlayerObject.ObjectTypes.Controller);
 
             //Setup controller event listeners
             controller.AliasPointerOn += new ControllerInteractionEventHandler(EnablePointerBeam);
@@ -256,7 +256,8 @@ namespace VRTK
         private void DrawPlayAreaCursorBoundary(int index, float left, float right, float top, float bottom, float thickness, Vector3 localPosition)
         {
             var playAreaCursorBoundary = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            playAreaCursorBoundary.name = string.Format("[{0}]PlayerObject_WorldPointer_PlayAreaCursorBoundary_" + index, this.gameObject.name);
+            playAreaCursorBoundary.name = string.Format("[{0}]WorldPointer_PlayAreaCursorBoundary_" + index, this.gameObject.name);
+            Utilities.SetPlayerObject(playAreaCursorBoundary, VRTK_PlayerObject.ObjectTypes.Pointer);
 
             var width = (right - left) / 1.065f;
             var length = (top - bottom) / 1.08f;
@@ -306,7 +307,8 @@ namespace VRTK
             var height = 0.01f;
 
             playAreaCursor = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            playAreaCursor.name = string.Format("[{0}]PlayerObject_WorldPointer_PlayAreaCursor", this.gameObject.name);
+            playAreaCursor.name = string.Format("[{0}]WorldPointer_PlayAreaCursor", this.gameObject.name);
+            Utilities.SetPlayerObject(playAreaCursor, VRTK_PlayerObject.ObjectTypes.Pointer);
             playAreaCursor.transform.parent = null;
             playAreaCursor.transform.localScale = new Vector3(width, height, length);
             playAreaCursor.SetActive(false);
@@ -361,7 +363,7 @@ namespace VRTK
 
         private void OnTriggerStay(Collider collider)
         {
-            if (parent.GetComponent<VRTK_WorldPointer>().IsActive() && !collider.name.Contains("PlayerObject_"))
+            if (parent.GetComponent<VRTK_WorldPointer>().IsActive() && !collider.GetComponent<VRTK_PlayerObject>())
             {
                 parent.GetComponent<VRTK_WorldPointer>().setPlayAreaCursorCollision(true);
             }
@@ -369,7 +371,7 @@ namespace VRTK
 
         private void OnTriggerExit(Collider collider)
         {
-            if (!collider.name.Contains("PlayerObject_"))
+            if (!collider.GetComponent<VRTK_PlayerObject>())
             {
                 parent.GetComponent<VRTK_WorldPointer>().setPlayAreaCursorCollision(false);
             }

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/Helper/Utilities.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/Helper/Utilities.cs
@@ -23,5 +23,14 @@
             }
             return true;
         }
+
+        public static void SetPlayerObject(GameObject obj, VRTK.VRTK_PlayerObject.ObjectTypes objType)
+        {
+            if(!obj.GetComponent<VRTK_PlayerObject>())
+            {
+                var playerObject = obj.AddComponent<VRTK_PlayerObject>();
+                playerObject.objectType = objType;
+            }
+        }
     }
 }

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/Helper/VRTK_PlayerObject.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/Helper/VRTK_PlayerObject.cs
@@ -1,0 +1,23 @@
+﻿//====================================================================================
+//
+// Purpose: Provide a way of tagging game objects as player specific objects to
+// allow other scripts to identify these specific objects without needing to use tags
+// or without needing to append the name of the game object. 
+//
+//====================================================================================
+namespace VRTK
+{
+    using UnityEngine;
+    public class VRTK_PlayerObject : MonoBehaviour
+    {
+        public enum ObjectTypes
+        {
+            CameraRig,
+            Headset,
+            Controller,
+            Pointer
+        }
+
+        public ObjectTypes objectType;
+    }
+}

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/Helper/VRTK_PlayerObject.cs.meta
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/Helper/VRTK_PlayerObject.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 24718813b1414a347a1bc9e6f1776a87
+timeCreated: 1467621214
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_BasicTeleport.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_BasicTeleport.cs
@@ -52,7 +52,8 @@ namespace VRTK
 
         protected virtual void Start()
         {
-            this.name = "PlayerObject_" + this.name;
+            Utilities.SetPlayerObject(this.gameObject, VRTK_PlayerObject.ObjectTypes.CameraRig);
+
             adjustYForTerrain = false;
             eyeCamera = GameObject.FindObjectOfType<SteamVR_Camera>().GetComponent<Transform>();
 

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_BezierPointer.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_BezierPointer.cs
@@ -62,11 +62,13 @@ namespace VRTK
         {
             pointerCursor = (customPointerCursor ? Instantiate(customPointerCursor) : CreateCursor());
 
-            pointerCursor.name = string.Format("[{0}]PlayerObject_WorldPointer_BezierPointer_PointerCursor", this.gameObject.name);
+            pointerCursor.name = string.Format("[{0}]WorldPointer_BezierPointer_PointerCursor", this.gameObject.name);
+            Utilities.SetPlayerObject(pointerCursor, VRTK_PlayerObject.ObjectTypes.Pointer);
             pointerCursor.layer = 2;
             pointerCursor.SetActive(false);
 
-            curvedBeamContainer = new GameObject(string.Format("[{0}]PlayerObject_WorldPointer_BezierPointer_CurvedBeamContainer", this.gameObject.name));
+            curvedBeamContainer = new GameObject(string.Format("[{0}]WorldPointer_BezierPointer_CurvedBeamContainer", this.gameObject.name));
+            Utilities.SetPlayerObject(curvedBeamContainer, VRTK_PlayerObject.ObjectTypes.Pointer);
             curvedBeamContainer.SetActive(false);
             curvedBeam = curvedBeamContainer.gameObject.AddComponent<CurveGenerator>();
             curvedBeam.transform.parent = null;
@@ -152,18 +154,22 @@ namespace VRTK
 
         private void InitProjectedBeams()
         {
-            projectedBeamContainer = new GameObject(string.Format("[{0}]PlayerObject_WorldPointer_BezierPointer_ProjectedBeamContainer", this.gameObject.name));
+            projectedBeamContainer = new GameObject(string.Format("[{0}]WorldPointer_BezierPointer_ProjectedBeamContainer", this.gameObject.name));
+            Utilities.SetPlayerObject(projectedBeamContainer, VRTK_PlayerObject.ObjectTypes.Pointer);
             projectedBeamContainer.transform.parent = this.transform;
             projectedBeamContainer.transform.localPosition = Vector3.zero;
 
-            projectedBeamForward = new GameObject(string.Format("[{0}]PlayerObject_WorldPointer_BezierPointer_ProjectedBeamForward", this.gameObject.name));
+            projectedBeamForward = new GameObject(string.Format("[{0}]WorldPointer_BezierPointer_ProjectedBeamForward", this.gameObject.name));
+            Utilities.SetPlayerObject(projectedBeamForward, VRTK_PlayerObject.ObjectTypes.Pointer);
             projectedBeamForward.transform.parent = projectedBeamContainer.transform;
 
-            projectedBeamJoint = new GameObject(string.Format("[{0}]PlayerObject_WorldPointer_BezierPointer_ProjectedBeamJoint", this.gameObject.name));
+            projectedBeamJoint = new GameObject(string.Format("[{0}]WorldPointer_BezierPointer_ProjectedBeamJoint", this.gameObject.name));
+            Utilities.SetPlayerObject(projectedBeamJoint, VRTK_PlayerObject.ObjectTypes.Pointer);
             projectedBeamJoint.transform.parent = projectedBeamContainer.transform;
             projectedBeamJoint.transform.localScale = new Vector3(0.01f, 0.01f, 0.01f);
 
-            projectedBeamDown = new GameObject(string.Format("[{0}]PlayerObject_WorldPointer_BezierPointer_ProjectedBeamDown", this.gameObject.name));
+            projectedBeamDown = new GameObject(string.Format("[{0}]WorldPointer_BezierPointer_ProjectedBeamDown", this.gameObject.name));
+            Utilities.SetPlayerObject(projectedBeamDown, VRTK_PlayerObject.ObjectTypes.Pointer);
         }
 
         private float GetForwardBeamLength()

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_HeadsetCollisionFade.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_HeadsetCollisionFade.cs
@@ -47,7 +47,8 @@
                 Debug.LogWarning("This 'VRTK_HeadsetCollisionFade' script needs a SteamVR_Fade script on the camera eye.");
             }
 
-            this.name = "PlayerObject_" + this.name;
+            Utilities.SetPlayerObject(this.gameObject, VRTK_PlayerObject.ObjectTypes.Headset);
+
             BoxCollider collider = this.gameObject.AddComponent<BoxCollider>();
             collider.isTrigger = true;
             collider.size = new Vector3(0.1f, 0.1f, 0.1f);
@@ -64,7 +65,7 @@
 
         protected void OnTriggerStay(Collider collider)
         {
-            if (!collider.name.Contains("PlayerObject_") && ValidTarget(collider.transform))
+            if (!collider.GetComponent<VRTK_PlayerObject>() && ValidTarget(collider.transform))
             {
                 OnHeadsetCollisionDetect(SetHeadsetCollisionEvent(collider, this.transform));
                 SteamVR_Fade.Start(fadeColor, blinkTransitionSpeed);
@@ -73,7 +74,7 @@
 
         protected void OnTriggerExit(Collider collider)
         {
-            if (!collider.name.Contains("PlayerObject_"))
+            if (!collider.GetComponent<VRTK_PlayerObject>())
             {
                 OnHeadsetCollisionEnded(SetHeadsetCollisionEvent(collider, this.transform));
                 SteamVR_Fade.Start(Color.clear, blinkTransitionSpeed);

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractTouch.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractTouch.cs
@@ -108,6 +108,8 @@ namespace VRTK
                 return;
             }
 
+            Utilities.SetPlayerObject(this.gameObject, VRTK_PlayerObject.ObjectTypes.Controller);
+
             CreateTouchCollider(this.gameObject);
             CreateControllerRigidBody();
         }

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_PlayerPresence.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_PlayerPresence.cs
@@ -25,7 +25,8 @@
 
         private void Start()
         {
-            this.name = "PlayerObject_" + this.name;
+            Utilities.SetPlayerObject(this.gameObject, VRTK_PlayerObject.ObjectTypes.CameraRig);
+
             lastGoodPositionSet = false;
             headset = DeviceFinder.HeadsetTransform();
             CreateCollider();

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_SimplePointer.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_SimplePointer.cs
@@ -51,12 +51,14 @@ namespace VRTK
 
         protected override void InitPointer()
         {
-            pointerHolder = new GameObject(string.Format("[{0}]PlayerObject_WorldPointer_SimplePointer_Holder", this.gameObject.name));
+            pointerHolder = new GameObject(string.Format("[{0}]WorldPointer_SimplePointer_Holder", this.gameObject.name));
+            Utilities.SetPlayerObject(pointerHolder, VRTK_PlayerObject.ObjectTypes.Pointer);
             pointerHolder.transform.parent = this.transform;
             pointerHolder.transform.localPosition = Vector3.zero;
 
             pointer = GameObject.CreatePrimitive(PrimitiveType.Cube);
-            pointer.transform.name = string.Format("[{0}]PlayerObject_WorldPointer_SimplePointer_Pointer", this.gameObject.name);
+            pointer.transform.name = string.Format("[{0}]WorldPointer_SimplePointer_Pointer", this.gameObject.name);
+            Utilities.SetPlayerObject(pointer, VRTK_PlayerObject.ObjectTypes.Pointer);
             pointer.transform.parent = pointerHolder.transform;
 
             pointer.GetComponent<BoxCollider>().isTrigger = true;
@@ -64,7 +66,8 @@ namespace VRTK
             pointer.layer = 2;
 
             pointerTip = GameObject.CreatePrimitive(PrimitiveType.Sphere);
-            pointerTip.transform.name = string.Format("[{0}]PlayerObject_WorldPointer_SimplePointer_PointerTip", this.gameObject.name);
+            pointerTip.transform.name = string.Format("[{0}]WorldPointer_SimplePointer_PointerTip", this.gameObject.name);
+            Utilities.SetPlayerObject(pointerTip, VRTK_PlayerObject.ObjectTypes.Pointer);
             pointerTip.transform.parent = pointerHolder.transform;
             pointerTip.transform.localScale = pointerTipScale;
 

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_TouchpadWalking.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_TouchpadWalking.cs
@@ -64,7 +64,7 @@
 
         private void Start()
         {
-            this.name = "PlayerObject_" + this.name;
+            Utilities.SetPlayerObject(this.gameObject, VRTK_PlayerObject.ObjectTypes.CameraRig);
 
             var controllerManager = GameObject.FindObjectOfType<SteamVR_ControllerManager>();
 


### PR DESCRIPTION
Previously, player objects were identified by the name of the game
object. This was done by certain scripts would rename the game object
and add the string `PlayerObject` which would then be looked up by
other scripts.

This was not an ideal solution as it meant renaming game objects which
could create confusion and mess in the editor at runtime. It's cleaner
and more extensible to add a custom script to these objects and they
are identified by the existence of the script.

The `VRTK_PlayerObject` script also allows to hint at what type of
object it is from the following types:

  * CameraRig
  * Headset
  * Controller
  * Pointer