### PR TITLE
fix(Interaction): prevent continuous rumble on touch

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractTouch.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractTouch.cs
@@ -35,6 +35,7 @@ namespace VRTK
         private SteamVR_TrackedObject trackedController;
         private VRTK_ControllerActions controllerActions;
         private GameObject controllerRigidBodyObject;
+        private bool triggerRumble;
 
         public virtual void OnControllerTouchInteractableObject(ObjectInteractEventArgs e)
         {
@@ -111,6 +112,7 @@ namespace VRTK
             Utilities.SetPlayerObject(this.gameObject, VRTK_PlayerObject.ObjectTypes.Controller);
             CreateTouchCollider(this.gameObject);
             CreateControllerRigidBody();
+            triggerRumble = false;
         }
 
         private void OnTriggerEnter(Collider collider)
@@ -157,11 +159,18 @@ namespace VRTK
                 }
 
                 var rumbleAmount = touchedObjectScript.rumbleOnTouch;
-                if (!rumbleAmount.Equals(Vector2.zero))
+                if (!rumbleAmount.Equals(Vector2.zero) && !triggerRumble)
                 {
+                    triggerRumble = true;
                     controllerActions.TriggerHapticPulse((ushort)rumbleAmount.y, rumbleAmount.x, 0.05f);
+                    Invoke("ResetTriggerRumble", rumbleAmount.x);
                 }
             }
+        }
+
+        private void ResetTriggerRumble()
+        {
+            triggerRumble = false;
         }
 
         private bool IsColliderChildOfTouchedObject(GameObject collider)


### PR DESCRIPTION
The touch rumble can get stuck in a loop if objects are touched in
quick succession. It's better to only allow for one rumble at a time
and let that rumble finish before triggering another rumble otherwise
the controller could be overloaded with rumble requests.