### PR TITLE
fix(Interaction): ensure touch state is reset on disable

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractableObject.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractableObject.cs
@@ -304,11 +304,13 @@ namespace VRTK
 
             if (grabbingObject != null)
             {
+                grabbingObject.GetComponent<VRTK_InteractTouch>().ForceStopTouching();
                 grabbingObject.GetComponent<VRTK_InteractGrab>().ForceRelease();
             }
 
             if (usingObject != null)
             {
+                usingObject.GetComponent<VRTK_InteractTouch>().ForceStopTouching();
                 usingObject.GetComponent<VRTK_InteractUse>().ForceStopUsing();
             }
         }


### PR DESCRIPTION
If an interactable object is touched and grabbed by one controller
but then another controller touches the object whilst it's grabbed
and then the object is disabled, the touch is not reset on the
original controller because it's not considered the touching obejct.

This fix ensures that the grabbing object and using object also
force the touch to be reset as well.