### PR TITLE
feat(Pointer): add option for custom pointer material

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Materials.meta
+++ b/Assets/SteamVR_Unity_Toolkit/Materials.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 49b403f7a7ceb964b9f86043dbbfab78
+folderAsset: yes
+timeCreated: 1467963682
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SteamVR_Unity_Toolkit/Materials/Resources.meta
+++ b/Assets/SteamVR_Unity_Toolkit/Materials/Resources.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 6ae7bb6535f0db4459a34fef4b701d7d
+folderAsset: yes
+timeCreated: 1467963687
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SteamVR_Unity_Toolkit/Materials/Resources/TooltipLine.mat
+++ b/Assets/SteamVR_Unity_Toolkit/Materials/Resources/TooltipLine.mat
@@ -1,0 +1,138 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: TooltipLine
+  m_Shader: {fileID: 10755, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 5
+  m_CustomRenderQueue: 2000
+  stringTagMap: {}
+  m_SavedProperties:
+    serializedVersion: 2
+    m_TexEnvs:
+      data:
+        first:
+          name: _MainTex
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+      data:
+        first:
+          name: _BumpMap
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+      data:
+        first:
+          name: _DetailNormalMap
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+      data:
+        first:
+          name: _MetallicGlossMap
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+      data:
+        first:
+          name: _ParallaxMap
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+      data:
+        first:
+          name: _OcclusionMap
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+      data:
+        first:
+          name: _EmissionMap
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+      data:
+        first:
+          name: _DetailMask
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+      data:
+        first:
+          name: _DetailAlbedoMap
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+    m_Floats:
+      data:
+        first:
+          name: _SrcBlend
+        second: 1
+      data:
+        first:
+          name: _DstBlend
+        second: 0
+      data:
+        first:
+          name: _Cutoff
+        second: 0.5
+      data:
+        first:
+          name: _ZWrite
+        second: 1
+      data:
+        first:
+          name: _Glossiness
+        second: 0.5
+      data:
+        first:
+          name: _Metallic
+        second: 0
+      data:
+        first:
+          name: _BumpScale
+        second: 1
+      data:
+        first:
+          name: _Parallax
+        second: 0.02
+      data:
+        first:
+          name: _OcclusionStrength
+        second: 1
+      data:
+        first:
+          name: _DetailNormalMapScale
+        second: 1
+      data:
+        first:
+          name: _UVSec
+        second: 0
+      data:
+        first:
+          name: _Mode
+        second: 0
+    m_Colors:
+      data:
+        first:
+          name: _EmissionColor
+        second: {r: 0, g: 0, b: 0, a: 1}
+      data:
+        first:
+          name: _Color
+        second: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/SteamVR_Unity_Toolkit/Materials/Resources/TooltipLine.mat.meta
+++ b/Assets/SteamVR_Unity_Toolkit/Materials/Resources/TooltipLine.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 167fe894cb53b584bbce353eb367fbda
+timeCreated: 1467963967
+licenseType: Pro
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SteamVR_Unity_Toolkit/Materials/Resources/UIText.mat
+++ b/Assets/SteamVR_Unity_Toolkit/Materials/Resources/UIText.mat
@@ -1,0 +1,162 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: UIText
+  m_Shader: {fileID: 4800000, guid: 1d91a0457b4ab7a458a9eac79648a51b, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 5
+  m_CustomRenderQueue: 3000
+  stringTagMap: {}
+  m_SavedProperties:
+    serializedVersion: 2
+    m_TexEnvs:
+      data:
+        first:
+          name: _MainTex
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+      data:
+        first:
+          name: _BumpMap
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+      data:
+        first:
+          name: _DetailNormalMap
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+      data:
+        first:
+          name: _MetallicGlossMap
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+      data:
+        first:
+          name: _ParallaxMap
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+      data:
+        first:
+          name: _OcclusionMap
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+      data:
+        first:
+          name: _EmissionMap
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+      data:
+        first:
+          name: _DetailMask
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+      data:
+        first:
+          name: _DetailAlbedoMap
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+    m_Floats:
+      data:
+        first:
+          name: _SrcBlend
+        second: 1
+      data:
+        first:
+          name: _DstBlend
+        second: 0
+      data:
+        first:
+          name: _Cutoff
+        second: 0.5
+      data:
+        first:
+          name: _ZWrite
+        second: 1
+      data:
+        first:
+          name: _Glossiness
+        second: 0.5
+      data:
+        first:
+          name: _Metallic
+        second: 0
+      data:
+        first:
+          name: _BumpScale
+        second: 1
+      data:
+        first:
+          name: _Parallax
+        second: 0.02
+      data:
+        first:
+          name: _OcclusionStrength
+        second: 1
+      data:
+        first:
+          name: _DetailNormalMapScale
+        second: 1
+      data:
+        first:
+          name: _UVSec
+        second: 0
+      data:
+        first:
+          name: _Mode
+        second: 0
+      data:
+        first:
+          name: _Stencil
+        second: 0
+      data:
+        first:
+          name: _StencilComp
+        second: 8
+      data:
+        first:
+          name: _StencilOp
+        second: 0
+      data:
+        first:
+          name: _StencilReadMask
+        second: 255
+      data:
+        first:
+          name: _StencilWriteMask
+        second: 255
+      data:
+        first:
+          name: _ColorMask
+        second: 15
+    m_Colors:
+      data:
+        first:
+          name: _EmissionColor
+        second: {r: 0, g: 0, b: 0, a: 1}
+      data:
+        first:
+          name: _Color
+        second: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/SteamVR_Unity_Toolkit/Materials/Resources/UIText.mat.meta
+++ b/Assets/SteamVR_Unity_Toolkit/Materials/Resources/UIText.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6feba24806ecd0e41b79c8531da69ae5
+timeCreated: 1467963930
+licenseType: Pro
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SteamVR_Unity_Toolkit/Materials/Resources/WorldPointer.mat
+++ b/Assets/SteamVR_Unity_Toolkit/Materials/Resources/WorldPointer.mat
@@ -1,0 +1,138 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: WorldPointer
+  m_Shader: {fileID: 4800000, guid: 4c84081e4523a5646919b30697cfccb8, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 5
+  m_CustomRenderQueue: 3000
+  stringTagMap: {}
+  m_SavedProperties:
+    serializedVersion: 2
+    m_TexEnvs:
+      data:
+        first:
+          name: _MainTex
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+      data:
+        first:
+          name: _BumpMap
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+      data:
+        first:
+          name: _DetailNormalMap
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+      data:
+        first:
+          name: _MetallicGlossMap
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+      data:
+        first:
+          name: _ParallaxMap
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+      data:
+        first:
+          name: _OcclusionMap
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+      data:
+        first:
+          name: _EmissionMap
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+      data:
+        first:
+          name: _DetailMask
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+      data:
+        first:
+          name: _DetailAlbedoMap
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+    m_Floats:
+      data:
+        first:
+          name: _SrcBlend
+        second: 1
+      data:
+        first:
+          name: _DstBlend
+        second: 0
+      data:
+        first:
+          name: _Cutoff
+        second: 0.5
+      data:
+        first:
+          name: _ZWrite
+        second: 1
+      data:
+        first:
+          name: _Glossiness
+        second: 0.5
+      data:
+        first:
+          name: _Metallic
+        second: 0
+      data:
+        first:
+          name: _BumpScale
+        second: 1
+      data:
+        first:
+          name: _Parallax
+        second: 0.02
+      data:
+        first:
+          name: _OcclusionStrength
+        second: 1
+      data:
+        first:
+          name: _DetailNormalMapScale
+        second: 1
+      data:
+        first:
+          name: _UVSec
+        second: 0
+      data:
+        first:
+          name: _Mode
+        second: 0
+    m_Colors:
+      data:
+        first:
+          name: _EmissionColor
+        second: {r: 0, g: 0, b: 0, a: 1}
+      data:
+        first:
+          name: _Color
+        second: {r: 0, g: 0.5, b: 0, a: 1}

--- a/Assets/SteamVR_Unity_Toolkit/Materials/Resources/WorldPointer.mat.meta
+++ b/Assets/SteamVR_Unity_Toolkit/Materials/Resources/WorldPointer.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dee83b4df08c2044dbb7465644a06cc2
+timeCreated: 1467963702
+licenseType: Pro
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
@@ -19,6 +19,7 @@ namespace VRTK
         }
 
         public VRTK_ControllerEvents controller = null;
+        public Material pointerMaterial;
         public Color pointerHitColor = new Color(0f, 0.5f, 0f, 1f);
         public Color pointerMissColor = new Color(0.8f, 0f, 0f, 1f);
         public bool showPlayAreaCursor = false;
@@ -33,7 +34,6 @@ namespace VRTK
         protected Transform pointerContactTarget = null;
         protected uint controllerIndex;
 
-        protected Material pointerMaterial;
         protected bool playAreaCursorCollided = false;
 
         private SteamVR_PlayArea playArea;
@@ -89,7 +89,13 @@ namespace VRTK
             playArea = GameObject.FindObjectOfType<SteamVR_PlayArea>();
             playAreaCursorBoundaries = new GameObject[4];
 
-            pointerMaterial = new Material(Shader.Find("Unlit/TransparentColor"));
+            var tmpMaterial = Resources.Load("WorldPointer") as Material;
+            if (pointerMaterial != null)
+            {
+                tmpMaterial = pointerMaterial;
+            }
+
+            pointerMaterial = new Material(tmpMaterial);
             pointerMaterial.color = pointerMissColor;
         }
 

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_ObjectTooltip.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_ObjectTooltip.cs
@@ -47,7 +47,7 @@
         private void SetText(string name)
         {
             var tmpText = this.transform.FindChild("TooltipCanvas/" + name).GetComponent<Text>();
-            tmpText.material = new Material(Shader.Find("UI/Overlay"));
+            tmpText.material = Resources.Load("UIText") as Material;
             tmpText.text = displayText;
             tmpText.color = fontColor;
             tmpText.fontSize = fontSize;
@@ -56,7 +56,7 @@
         private void SetLine()
         {
             line = this.transform.FindChild("Line").GetComponent<LineRenderer>();
-            line.material = new Material(Shader.Find("Unlit/Color"));
+            line.material = Resources.Load("TooltipLine") as Material;
             line.material.color = lineColor;
             line.SetColors(lineColor, lineColor);
             line.SetWidth(lineWidth, lineWidth);

--- a/ProjectSettings/GraphicsSettings.asset
+++ b/ProjectSettings/GraphicsSettings.asset
@@ -20,7 +20,6 @@ GraphicsSettings:
   - {fileID: 15106, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 10782, guid: 0000000000000000f000000000000000, type: 0}
-  - {fileID: 4800000, guid: 4c84081e4523a5646919b30697cfccb8, type: 3}
   m_PreloadedShaders: []
   m_ShaderSettings:
     useScreenSpaceShadows: 1

--- a/README.md
+++ b/README.md
@@ -400,6 +400,9 @@ The following script parameters are available:
   pointer. If the script is being applied onto a controller then this
   parameter can be left blank as it will be auto populated by the
   controller the script is on at runtime.
+  * **Pointer Material:** The material to use on the rendered version
+  of the pointer. If no material is selected then the default
+  `WorldPointer` material will be used.
   * **Pointer Hit Color:** The colour of the beam when it is colliding
   with a valid target. It can be set to a different colour for each
   controller.
@@ -483,6 +486,9 @@ The following script parameters are available:
   pointer. If the script is being applied onto a controller then this
   parameter can be left blank as it will be auto populated by the
   controller the script is on at runtime.
+  * **Pointer Material:** The material to use on the rendered version
+  of the pointer. If no material is selected then the default
+  `WorldPointer` material will be used.
   * **Pointer Hit Color:** The colour of the beam when it is colliding
   with a valid target. It can be set to a different colour for each
   controller.
@@ -1482,6 +1488,9 @@ The following script parameters are available:
   pointer. If the script is being applied onto a controller then this
   parameter can be left blank as it will be auto populated by the
   controller the script is on at runtime.
+  * **Pointer Material:** The material to use on the rendered version
+  of the pointer. If no material is selected then the default
+  `WorldPointer` material will be used.
   * **Pointer Hit Color:** The colour of the beam when it is colliding
   with a valid target. It can be set to a different colour for each
   controller.


### PR DESCRIPTION
The World Pointer material can now be set as a parameter on any
pointer via the `Pointer Material` option in the inspector. If no
material is provided then a default material is loaded from the new
`Materials` directory.

This new `Materials` directory also provides the ability to load
required materials at runtime rather than trying to create them via
code using non-standard shaders. The approach of `Shader.Find` causes
build issues if the shader is not included in the
`Project Settings->Graphics->Shaders` option, but if there is a
material in the project that is using that shader then the build
process will automatically include the shader so there is no need to
manually update the settings.