### PR TITLE
feat (Interaction): make 3D controls expose UnityEvents

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Examples/Resources/Scripts/ButtonReactor.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Examples/Resources/Scripts/ButtonReactor.cs
@@ -8,7 +8,7 @@ public class ButtonReactor : MonoBehaviour
 
     private void Start()
     {
-        GetComponent<VRTK_Button>().OnPushed += handlePush;
+        GetComponent<VRTK_Button>().events.OnPush.AddListener(handlePush);
     }
 
     private void handlePush()

--- a/Assets/SteamVR_Unity_Toolkit/Examples/Resources/Scripts/ControlReactor.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Examples/Resources/Scripts/ControlReactor.cs
@@ -7,7 +7,7 @@ public class ControlReactor : MonoBehaviour
 
     private void Start()
     {
-        GetComponent<VRTK_Control>().OnValueChanged += HandleChange;
+        GetComponent<VRTK_Control>().defaultEvents.OnValueChanged.AddListener(HandleChange);
         go.text = GetComponent<VRTK_Control>().getValue().ToString();
     }
 

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/Controls/3D/VRTK_Button.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/Controls/3D/VRTK_Button.cs
@@ -1,20 +1,26 @@
 ﻿namespace VRTK
 {
     using UnityEngine;
+    using UnityEngine.Events;
 
     public class VRTK_Button : VRTK_Control
     {
+        [System.Serializable]
+        public class ButtonEvents
+        {
+            public UnityEvent OnPush;
+        }
+
         public enum Direction
         {
             autodetect, x, y, z, negX, negY, negZ
         }
 
+        public ButtonEvents events;
+
         public Direction direction = Direction.autodetect;
         public float activationDistance = 1.0f;
         public float buttonStrength = 5.0f;
-
-        public delegate void PushAction();
-        public event PushAction OnPushed;
 
         private static float MAX_AUTODETECT_ACTIVATION_LENGTH = 4; // full hight of button
 
@@ -164,10 +170,7 @@
                 if (oldState == 0)
                 {
                     value = 1;
-                    if (OnPushed != null)
-                    {
-                        OnPushed();
-                    }
+                    events.OnPush.Invoke();
                 }
             }
             else

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/Controls/VRTK_Control.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/Controls/VRTK_Control.cs
@@ -1,15 +1,24 @@
 ﻿namespace VRTK
 {
     using UnityEngine;
+    using UnityEngine.Events;
 
     [ExecuteInEditMode]
     public abstract class VRTK_Control : MonoBehaviour
     {
+        [System.Serializable]
+        public class ValueChangedEvent : UnityEvent<float> { }
+
+        [System.Serializable]
+        public class DefaultControlEvents
+        {
+            public ValueChangedEvent OnValueChanged;
+        }
+
         private static Color COLOR_OK = Color.yellow;
         private static Color COLOR_ERROR = new Color(1, 0, 0, 0.9f);
 
-        public delegate void ValueChange(float value);
-        public event ValueChange OnValueChanged;
+        public DefaultControlEvents defaultEvents;
 
         abstract protected void InitRequiredComponents();
         abstract protected bool DetectSetup();
@@ -48,10 +57,7 @@
                 // trigger events
                 if (value != oldValue)
                 {
-                    if (OnValueChanged != null)
-                    {
-                        OnValueChanged(getValue());
-                    }
+                    defaultEvents.OnValueChanged.Invoke(getValue());
                 }
             }
         }


### PR DESCRIPTION
Controls now expose UnityEvents which are neatly exposing their own
inspector UI so that it becomes very easy to wire controls together
through configuration instead of using code. Programmatic access is
still possible.

The events are wrapped in event container classed to fold them per
default in the inspector.