### PR TITLE
fix(Teleport): ensure teleporting sets y position correctly

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_BasicTeleport.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_BasicTeleport.cs
@@ -136,7 +136,8 @@ namespace VRTK
         {
             if (adjustYForTerrain && target.GetComponent<Terrain>())
             {
-                position.y = Terrain.activeTerrain.SampleHeight(position);
+                var terrainHeight = Terrain.activeTerrain.SampleHeight(position);
+                position.y = (terrainHeight > position.y ? position.y : terrainHeight);
             }
             return position;
         }

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_HeightAdjustTeleport.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_HeightAdjustTeleport.cs
@@ -46,11 +46,13 @@ namespace VRTK
         {
             float newY = this.transform.position.y;
             //Check to see if the tip is on top of an object
-            if (target && (tipPosition.y + 0.5f) > (target.position.y + (target.localScale.y / 2)))
+            var rayStartPositionOffset = Vector3.up * 0.1f;
+            var ray = new Ray(tipPosition + rayStartPositionOffset, -transform.up);
+            RaycastHit rayCollidedWith;
+            if (target && Physics.Raycast(ray, out rayCollidedWith))
             {
-                newY = tipPosition.y;
+                newY = tipPosition.y - rayCollidedWith.distance;
             }
-
             return newY;
         }
 


### PR DESCRIPTION
There are occasions when the pointer tip position would report being
above the target teleport location, or other times where the target
location wasn't being considered valid so the `[CameraRig]` y position
wasn't being updated leaving the player hanging in mid air.

This is because the logic to determine the destination y relied on
the target object having a defined center and height, which could
produce flakey results.

This has now been replaced and a ray is cast from the pointer tip
(with a slight height offset to ensure it avoids clipping with the
target surface). The ray is cast downwards and looks for the top of
the object the user should be standing on. This produces more
consistent results for both the bezier pointer and simple pointer
across many different surface types.

The terrain height check should also ensure negative height terrains
adhere to the correct destination height as well.