### PR TITLE
fix(Locomotion): add null check for Play Area

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
@@ -106,7 +106,7 @@ namespace VRTK
                 activateDelayTimer -= Time.deltaTime;
             }
 
-            if (playAreaCursor.activeSelf)
+            if (playAreaCursor && playAreaCursor.activeSelf)
             {
                 UpdateCollider();
             }


### PR DESCRIPTION
Game objects which are set to not destroy on level load and that contain a
VRTK_Bezier Pointer script will throw a null exception for the Play Area on the
next level load.

This commit fixes that by adding a null reference check to the Play Area.