### PR TITLE
fix(Interaction): ensure tracked object stays grabbed on teleport

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractableObject.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractableObject.cs
@@ -320,6 +320,14 @@ namespace VRTK
             grabbedSnapHandle = handle;
         }
 
+        public void RegisterTeleporters()
+        {
+            foreach (var teleporter in GameObject.FindObjectsOfType<VRTK_BasicTeleport>())
+            {
+                teleporter.Teleported += new TeleportEventHandler(OnTeleported);
+            }
+        }
+
         protected virtual void Awake()
         {
             rb = this.GetComponent<Rigidbody>();
@@ -336,6 +344,7 @@ namespace VRTK
         protected virtual void Start()
         {
             originalObjectColours = StoreOriginalColors();
+            RegisterTeleporters();
         }
 
         protected virtual void Update()
@@ -527,6 +536,14 @@ namespace VRTK
 
                 Vector3 velocityTarget = positionDelta / Time.fixedDeltaTime;
                 rb.velocity = Vector3.MoveTowards(rb.velocity, velocityTarget, maxDistanceDelta);
+            }
+        }
+
+        private void OnTeleported(object sender, DestinationMarkerEventArgs e)
+        {
+            if (grabAttachMechanic == GrabAttachType.Track_Object && trackPoint)
+            {
+                this.transform.position = grabbingObject.transform.position;
             }
         }
     }


### PR DESCRIPTION
Previously, if a tracked object was being grabbed and the player
teleported, the tracked object would not have it's position updated
after the teleport event, meaning the tracked object would whizz to
the player's current location and detach from their hand.

This fix, listens out for any teleport events and updates the
tracked object's position based on the controller that is holding it.