### PR TITLE
feat(Pointer): add custom cursor option for the simple pointer

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_SimplePointer.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_SimplePointer.cs
@@ -22,6 +22,7 @@ namespace VRTK
         public float pointerThickness = 0.002f;
         public float pointerLength = 100f;
         public bool showPointerTip = true;
+        public GameObject customPointerCursor;
         public LayerMask layersToIgnore = Physics.IgnoreRaycastLayer;
 
         private GameObject pointerHolder;
@@ -65,13 +66,20 @@ namespace VRTK
             pointer.AddComponent<Rigidbody>().isKinematic = true;
             pointer.layer = LayerMask.NameToLayer("Ignore Raycast");
 
-            pointerTip = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+            if(customPointerCursor == null)
+            {
+                pointerTip = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+                pointerTip.transform.localScale = pointerTipScale;
+            } else
+            {
+                pointerTip = Instantiate(customPointerCursor);
+            }
+
             pointerTip.transform.name = string.Format("[{0}]WorldPointer_SimplePointer_PointerTip", this.gameObject.name);
             Utilities.SetPlayerObject(pointerTip, VRTK_PlayerObject.ObjectTypes.Pointer);
             pointerTip.transform.parent = pointerHolder.transform;
-            pointerTip.transform.localScale = pointerTipScale;
 
-            pointerTip.GetComponent<SphereCollider>().isTrigger = true;
+            pointerTip.GetComponent<Collider>().isTrigger = true;
             pointerTip.AddComponent<Rigidbody>().isKinematic = true;
             pointerTip.layer = LayerMask.NameToLayer("Ignore Raycast");
 

--- a/README.md
+++ b/README.md
@@ -474,6 +474,8 @@ The following script parameters are available:
   stopping.
   * **Show Pointer Tip:** Toggle whether the cursor is shown on the end
   of the pointer beam.
+  * **Custom Pointer Cursor:** A custom Game Object can be applied
+  here to use instead of the default sphere for the pointer cursor.
   * **Layers To Ignore:** The layers to ignore when raycasting.
 
 The Simple Pointer object extends the `VRTK_WorldPointer` abstract


### PR DESCRIPTION
It's now possible to provide a custom pointer cursor game obejct for
the Simple Pointer. This gameobject will be used for the pointer tip
rather than the default sphere. If no game object is provided then the
default sphere is still used.