### PR TITLE
feat(Pointer): add seperate button for destination set

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
@@ -43,6 +43,7 @@ namespace VRTK
         private BoxCollider playAreaCursorCollider;
         private Transform headset;
         private bool isActive;
+        private bool destinationSetActive;
         private bool eventsRegistered = false;
 
         private float activateDelayTimer = 0f;
@@ -83,6 +84,8 @@ namespace VRTK
             //Setup controller event listeners
             controller.AliasPointerOn += new ControllerInteractionEventHandler(EnablePointerBeam);
             controller.AliasPointerOff += new ControllerInteractionEventHandler(DisablePointerBeam);
+            controller.AliasPointerSet += new ControllerInteractionEventHandler(SetPointerDestination);
+
             eventsRegistered = true;
 
             headset = DeviceFinder.HeadsetTransform();
@@ -119,6 +122,7 @@ namespace VRTK
             {
                 controller.AliasPointerOn -= EnablePointerBeam;
                 controller.AliasPointerOff -= DisablePointerBeam;
+                controller.AliasPointerSet -= SetPointerDestination;
             }
 
             if (playAreaCursor != null)
@@ -152,6 +156,7 @@ namespace VRTK
                 controllerIndex = e.controllerIndex;
                 TogglePointer(true);
                 isActive = true;
+                destinationSetActive = true;
             }
         }
 
@@ -164,6 +169,11 @@ namespace VRTK
                 TogglePointer(false);
                 isActive = false;
             }
+        }
+
+        protected virtual void SetPointerDestination(object sender, ControllerInteractionEventArgs e)
+        {
+            PointerSet();
         }
 
         protected virtual void PointerIn()
@@ -200,7 +210,7 @@ namespace VRTK
 
         protected virtual void PointerSet()
         {
-            if (!this.enabled || !isActive || !pointerContactTarget)
+            if (!this.enabled || !destinationSetActive || !pointerContactTarget)
             {
                 return;
             }
@@ -221,6 +231,11 @@ namespace VRTK
             if (!playAreaCursorCollided && (interactableObject == null || !interactableObject.pointerActivatesUseAction))
             {
                 OnDestinationMarkerSet(SetDestinationMarkerEvent(pointerContactDistance, pointerContactTarget, destinationPosition, controllerIndex));
+            }
+
+            if (!isActive)
+            {
+                destinationSetActive = false;
             }
         }
 

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_BezierPointer.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_BezierPointer.cs
@@ -102,7 +102,6 @@ namespace VRTK
 
         protected override void DisablePointerBeam(object sender, ControllerInteractionEventArgs e)
         {
-            base.PointerSet();
             base.DisablePointerBeam(sender, e);
             TogglePointerCursor(false);
             curvedBeam.TogglePoints(false);

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_ControllerEvents.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_ControllerEvents.cs
@@ -25,6 +25,7 @@
         }
 
         public ButtonAlias pointerToggleButton = ButtonAlias.Touchpad_Press;
+        public ButtonAlias pointerSetButton = ButtonAlias.Touchpad_Press;
         public ButtonAlias grabToggleButton = ButtonAlias.Grip;
         public ButtonAlias useToggleButton = ButtonAlias.Trigger;
         public ButtonAlias menuToggleButton = ButtonAlias.Application_Menu;
@@ -65,6 +66,7 @@
 
         public event ControllerInteractionEventHandler AliasPointerOn;
         public event ControllerInteractionEventHandler AliasPointerOff;
+        public event ControllerInteractionEventHandler AliasPointerSet;
 
         public event ControllerInteractionEventHandler AliasGrabOn;
         public event ControllerInteractionEventHandler AliasGrabOff;
@@ -167,6 +169,12 @@
         {
             if (AliasPointerOff != null)
                 AliasPointerOff(this, e);
+        }
+
+        public virtual void OnAliasPointerSet(ControllerInteractionEventArgs e)
+        {
+            if (AliasPointerSet != null)
+                AliasPointerSet(this, e);
         }
 
         public virtual void OnAliasGrabOn(ControllerInteractionEventArgs e)
@@ -280,6 +288,14 @@
                 {
                     pointerPressed = false;
                     OnAliasPointerOff(SetButtonEvent(ref buttonBool, false, buttonPressure));
+                }
+            }
+
+            if (pointerSetButton == type)
+            {
+                if (! touchDown)
+                {
+                    OnAliasPointerSet(SetButtonEvent(ref buttonBool, true, buttonPressure));
                 }
             }
 

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_SimplePointer.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_SimplePointer.cs
@@ -120,12 +120,6 @@ namespace VRTK
             }
         }
 
-        protected override void DisablePointerBeam(object sender, ControllerInteractionEventArgs e)
-        {
-            base.PointerSet();
-            base.DisablePointerBeam(sender, e);
-        }
-
         private void SetPointerTransform(float setLength, float setThicknes)
         {
             //if the additional decimal isn't added then the beam position glitches

--- a/README.md
+++ b/README.md
@@ -380,6 +380,8 @@ buttons are pressed. These action aliases can be mapped to a
 preferred controller button. The aliases are:
 
   * **Toggle Pointer:** Common action of turning a laser pointer on/off
+  * **Pointer Set:** Common action of setting a destination marker from
+  the cursor position of the pointer
   * **Toggle Grab:** Common action of grabbing game objects
   * **Toggle Use:** Common action of using game objects
   * **Toggle Menu:** Common action of bringing up an in-game menu
@@ -388,10 +390,11 @@ Each of the above aliases can have the preferred controller button
 mapped to their usage by selecting it from the drop down on the script
 parameters window.
 
-When the set button is pressed it will emit the actual button event as
-well as an additional event that the alias is "On". When the set button
-is released it will emit the actual button event as well as an
-additional event that the alias button is "Off".
+When the relevant button is pressed it will emit the actual button
+event as well as an additional event that the alias is `On`. When
+the set button is released it will emit the actual button event as
+well as an additional event that the alias button is `Off`. The
+`Pointer Set` alias is only triggered when the button is released.
 
 Listening for these alias events rather than the actual button events
 means it's easier to customise the controller buttons to the actions
@@ -684,7 +687,8 @@ scene `SteamVR_Unity_Toolkit/Examples/004_CameraRig_BasicTeleport`.
 The scene uses the `VRTK_SimplePointer` script on the Controllers to
 initiate a laser pointer by pressing the `Touchpad` on the controller
 and when the laser pointer is deactivated (release the `Touchpad`)
-then the user is teleported to the location of the laser pointer tip.
+then the user is teleported to the location of the laser pointer tip
+as this is where the pointer destination marker position is set to.
 
 #### Height Adjustable Teleporter (VRTK_HeightAdjustTeleport)
 


### PR DESCRIPTION
It is now possible to have separate buttons for activating/deactivating
the pointer beam and setting the pointer destination marker.

This is useful if a pointer beam is required but teleport is wanted on
a different button press.