### PR TITLE
feat(Teleport): Allow multiple tags and component types to be specified as invalid teleport locations

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_DestinationMarker.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_DestinationMarker.cs
@@ -22,6 +22,7 @@ namespace VRTK
 {
     using UnityEngine;
     using System.Collections;
+    using System.Collections.Generic;
 
     public struct DestinationMarkerEventArgs
     {
@@ -42,7 +43,8 @@ namespace VRTK
         public event DestinationMarkerEventHandler DestinationMarkerExit;
         public event DestinationMarkerEventHandler DestinationMarkerSet;
 
-        protected string invalidTargetWithTagOrClass;
+        protected List<string> ignoreTargetWithTags;
+        protected List<string> ignoreTargetWithComponents;
         protected bool checkNavMesh;
         protected bool headsetPositionCompensation;
 
@@ -64,9 +66,10 @@ namespace VRTK
                 DestinationMarkerSet(this, e);
         }
 
-        public virtual void SetInvalidTarget(string name)
+        public virtual void SetInvalidTargets(List<string> ignoreTagsList, List<string> ignoreComponents)
         {
-            invalidTargetWithTagOrClass = name;
+            ignoreTargetWithTags = ignoreTagsList;
+            ignoreTargetWithComponents = ignoreComponents;
         }
 
         public virtual void SetNavMeshCheck(bool state)

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
@@ -7,7 +7,9 @@
 namespace VRTK
 {
     using UnityEngine;
+    using System;
     using System.Collections;
+    using System.Collections.Generic;
 
     public abstract class VRTK_WorldPointer : VRTK_DestinationMarker
     {
@@ -106,7 +108,7 @@ namespace VRTK
                 activateDelayTimer -= Time.deltaTime;
             }
 
-            if (playAreaCursor && playAreaCursor.activeSelf)
+            if (playAreaCursor.activeSelf)
             {
                 UpdateCollider();
             }
@@ -247,6 +249,48 @@ namespace VRTK
             SetPointerMaterial();
         }
 
+        /// <summary>
+        /// Determines if a teleport location is valid given a list of names (eg tags or component names) 
+        /// and an appropriate lookup function (eg Transform.CompareTag).
+        /// </summary>
+        /// <param name="invalidTagsOrComponentNames"></param>
+        /// <param name="function"></param>
+        /// <returns>true is the teleport destination is valid</returns>
+        public static bool IsDestinationStringValid(List<string> invalidTagsOrComponentNames, Func<string, bool> function)
+        {
+            var isValid = true;
+            foreach (var tag in invalidTagsOrComponentNames)
+            {
+                if (function(tag))
+                {
+                    isValid = false;
+                    break;
+                }
+            }
+            return isValid;
+        }
+
+        /// <summary>
+        /// Checks that the given transform is a valid teleport location based on the disallowed tags and 
+        /// component types provided. A null target is also implicitly considered an invalid teleportation target.
+        /// </summary>
+        /// <param name="target"></param>
+        /// <param name="invalidTags"></param>
+        /// <param name="invalidComponentNames"></param>
+        /// <returns>true if teleportation to this target is allowed</returns>
+        public static bool IsValidTagOrComponentDestination(Transform target, List<string> invalidTags, List<string> invalidComponentNames)
+        {
+            bool validTag = false;
+            bool validComponent = false;
+            if (target != null)
+            {
+                validTag = IsDestinationStringValid(invalidTags, target.CompareTag);
+                validComponent = IsDestinationStringValid(invalidComponentNames, x => target.GetComponent(x) != null);
+            }
+
+            return (validTag && validComponent);
+        }
+
         protected virtual bool ValidDestination(Transform target)
         {
             bool validNavMeshLocation = false;
@@ -259,7 +303,10 @@ namespace VRTK
             {
                 validNavMeshLocation = true;
             }
-            return (validNavMeshLocation && target && target.tag != invalidTargetWithTagOrClass && target.GetComponent(invalidTargetWithTagOrClass) == null);
+
+            var validTagOrComponent = IsValidTagOrComponentDestination(target, ignoreTargetWithTags, ignoreTargetWithComponents);
+
+            return (validNavMeshLocation && validTagOrComponent);
         }
 
         private void DrawPlayAreaCursorBoundary(int index, float left, float right, float top, float bottom, float thickness, Vector3 localPosition)

--- a/README.md
+++ b/README.md
@@ -664,11 +664,15 @@ The following script parameters are available:
   play area. If it is unchecked then the teleported location will
   always be the centre of the play area even if the headset position
   is not in the centre of the play area.
-  * **Ignore Target With Tag Or Class:** A string that specifies an
-  object Tag or the name of a Script attached to an obejct and
-  notifies the teleporter that the destination is to be ignored so
-  the user cannot teleport to that location. It also ensure the
-  pointer colour is set to the miss colour.
+  * **Ignore Target With Tags:** A list of strings specifying any
+  object Tags that should be treated as invalid as teleportation 
+  destinations, so the user cannot teleport to that location.
+  It also ensures the pointer colour is set to the miss colour.
+  * **Ignore Target With Components:** A list of strings specifying the
+  name of any Script that when found on an object should be treated as 
+  an invalid teleportation destination, preventing the user from 
+  teleporting to that location. It also ensures the pointer colour is 
+  set to the miss colour.
   * **Limit To Nav Mesh:** If this is checked then teleporting will
   be limited to the bounds of a baked NavMesh. If the pointer
   destination is outside the NavMesh then it will be ignored.
@@ -706,11 +710,15 @@ The following script parameters are available:
   play area. If it is unchecked then the teleported location will
   always be the centre of the play area even if the headset position
   is not in the centre of the play area.
-  * **Ignore Target With Tag Or Class:** A string that specifies an
-  object Tag or the name of a Script attached to an obejct and
-  notifies the teleporter that the destination is to be ignored so
-  the user cannot teleport to that location. It also ensure the
-  pointer colour is set to the miss colour.
+  * **Ignore Target With Tags:** A list of strings specifying any
+  object Tags that should be treated as invalid as teleportation 
+  destinations, so the user cannot teleport to that location.
+  It also ensures the pointer colour is set to the miss colour.
+  * **Ignore Target With Components:** A list of strings specifying the
+  name of any Script that when found on an object should be treated as 
+  an invalid teleportation destination, preventing the user from 
+  teleporting to that location. It also ensures the pointer colour is 
+  set to the miss colour.
   * **Limit To Nav Mesh:** If this is checked then teleporting will
   be limited to the bounds of a baked NavMesh. If the pointer
   destination is outside the NavMesh then it will be ignored.


### PR DESCRIPTION
This patch allows multiple tags and component types to be specified as invalid teleport locations. It also prevents a potential corner case bug that could have occurred when a tag had the same name as component class. 

Reduces some code duplication by putting some of the common code into static methods on VRTK_WorldPointer (I'm not sure this is the ideal place, it feels like there should be a dedicated 'teleportation target validation' component to do the handle the common business logic for both the pointer/marker renderers and any teleportation movers like VRTK_BasicTeleport).