### PR TITLE
feat(Pointer): teleport timer

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
@@ -162,9 +162,8 @@ namespace VRTK
 
         protected virtual void DisablePointerBeam(object sender, ControllerInteractionEventArgs e)
         {
-            if (isActive && activateDelayTimer <= 0)
+            if (isActive)
             {
-                activateDelayTimer = activateDelay;
                 controllerIndex = e.controllerIndex;
                 TogglePointer(false);
                 isActive = false;
@@ -173,7 +172,11 @@ namespace VRTK
 
         protected virtual void SetPointerDestination(object sender, ControllerInteractionEventArgs e)
         {
-            PointerSet();
+            if (activateDelayTimer <= 0)
+            {
+                activateDelayTimer = activateDelay;
+                PointerSet();
+            }
         }
 
         protected virtual void PointerIn()


### PR DESCRIPTION
The current behaviour of the teleport, when the Activate Delay Timer is not 0,
can lead to feel like it is not working (tested with the Pointer Toggle Button
 set to "Touchpad_touch" and  thePointer Set Button set to "Touchpad_Press").

Some users sometimes double-click the teleport button, thus if no timer is set
the teleport is activated twice.

Furthermore when the button is released the beam cannot be activated soon
because of the timer and user feels like that the button is not responding.
