### PR TITLE
fix(Pointer): activate delay timer for teleport

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
@@ -162,9 +162,8 @@ namespace VRTK
 
         protected virtual void DisablePointerBeam(object sender, ControllerInteractionEventArgs e)
         {
-            if (isActive && activateDelayTimer <= 0)
+            if (isActive)
             {
-                activateDelayTimer = activateDelay;
                 controllerIndex = e.controllerIndex;
                 TogglePointer(false);
                 isActive = false;
@@ -173,7 +172,11 @@ namespace VRTK
 
         protected virtual void SetPointerDestination(object sender, ControllerInteractionEventArgs e)
         {
-            PointerSet();
+            if (activateDelayTimer <= 0)
+            {
+                activateDelayTimer = activateDelay;
+                PointerSet();
+            }
         }
 
         protected virtual void PointerIn()


### PR DESCRIPTION
Prevent multiple undesired teleport.

Even if the teleport activateDelayTimer is set, when users double-click
the teleport button, the teleport is activated twice.

Check the timer in VRTK_WorldPointer.SetPointerDestination() to prevent
this.

When the button is released let the beam be disabled immediately,
otherwise the beam cannot be activated again because of the timer and a
user feels like the button is not responding.