### PR TITLE
feat(RadialMenu): add OnHoverEnter / OnHoverExit events to RadialMenu buttons

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/Controls/2D/RadialMenu/RadialMenu.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/Controls/2D/RadialMenu/RadialMenu.cs
@@ -48,7 +48,7 @@ public class RadialMenu : MonoBehaviour
         //Keep track of pressed button and constantly invoke Hold event
         if (currentPress != -1)
         {
-            buttons[currentPress].Press();
+            buttons[currentPress].OnHold.Invoke();
         }
     }
 
@@ -71,12 +71,13 @@ public class RadialMenu : MonoBehaviour
         {
             ExecuteEvents.Execute(menuButtons[currentHover], pointer, ExecuteEvents.pointerUpHandler);
             ExecuteEvents.Execute(menuButtons[currentHover], pointer, ExecuteEvents.pointerExitHandler);
+            buttons[currentHover].OnHoverExit.Invoke();
         }
         if (evt == ButtonEvent.click) //Click button if click, and keep track of current press
         {
             ExecuteEvents.Execute(menuButtons[buttonID], pointer, ExecuteEvents.pointerDownHandler);
             currentPress = buttonID;
-            buttons[buttonID].Click();
+            buttons[buttonID].OnClick.Invoke();
         }
         else if (evt == ButtonEvent.unclick) //Clear press id to stop invoking OnHold method
         {
@@ -86,6 +87,7 @@ public class RadialMenu : MonoBehaviour
         else if (evt == ButtonEvent.hoverOn && currentHover != buttonID) // Show hover UI event (darken button etc)
         {
             ExecuteEvents.Execute(menuButtons[buttonID], pointer, ExecuteEvents.pointerEnterHandler);
+            buttons[buttonID].OnHoverEnter.Invoke();
         }
         currentHover = buttonID; //Set current hover ID, need this to un-hover if selected button changes
     }
@@ -127,6 +129,7 @@ public class RadialMenu : MonoBehaviour
         {
             var pointer = new PointerEventData(EventSystem.current);
             ExecuteEvents.Execute(menuButtons[currentHover], pointer, ExecuteEvents.pointerExitHandler);
+            buttons[currentHover].OnHoverExit.Invoke();
             currentHover = -1;
         }
     }
@@ -295,18 +298,11 @@ public class RadialMenu : MonoBehaviour
 public class RadialMenuButton
 {
     public Sprite ButtonIcon;
+
     public UnityEvent OnClick;
     public UnityEvent OnHold;
-
-    public void Press()
-    {
-        OnHold.Invoke();
-    }
-
-    public void Click()
-    {
-        OnClick.Invoke();
-    }
+    public UnityEvent OnHoverEnter;
+    public UnityEvent OnHoverExit;
 }
 
 public enum ButtonEvent

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -124,6 +124,8 @@ There are a number of parameters that can be set on the Prefab which are provide
    * **ButtonIcon:** Icon to use inside the button arc (should be circular).
    * **OnClick():** Methods to invoke when the button is clicked.
    * **OnHold():** Methods to invoke each frame while the button is held down.
+   * **OnHoverEnter():** Methods to invoke when button is first hovered over.
+   * **OnHoverExit():** Methods to invoke when button leaves the hovered state.
   * **Button Prefab:** The base for each button in the menu, by default set to a dynamic circle arc that will fill up a portion of the menu.
   * **Button Thickness:** Percentage of the menu the buttons should fill, 1.0 is a pie slice, 0.1 is a thin ring.
   * **Button Color:** The background color of the buttons, default is white.


### PR DESCRIPTION
This allows events to be triggered when the button enters/exits the hovered state.
An example use case is showing/hiding of an attached laser pointer component depending on which button is being hovered over.