### PR TITLE
fix(Pointer): ensure activate delay only happens on destination set

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
@@ -162,9 +162,8 @@ namespace VRTK
 
         protected virtual void DisablePointerBeam(object sender, ControllerInteractionEventArgs e)
         {
-            if (isActive && activateDelayTimer <= 0)
+            if (isActive)
             {
-                activateDelayTimer = activateDelay;
                 controllerIndex = e.controllerIndex;
                 TogglePointer(false);
                 isActive = false;
@@ -210,10 +209,12 @@ namespace VRTK
 
         protected virtual void PointerSet()
         {
-            if (!this.enabled || !destinationSetActive || !pointerContactTarget)
+            if (!this.enabled || !destinationSetActive || !pointerContactTarget || activateDelayTimer > 0)
             {
                 return;
             }
+
+            activateDelayTimer = activateDelay;
 
             var interactableObject = pointerContactTarget.GetComponent<VRTK_InteractableObject>();
             if (interactableObject && interactableObject.pointerActivatesUseAction)


### PR DESCRIPTION
Previously, the activation delay on a pointer would happen when the
pointer was disabled, but this gave the impression that the pointer
was not working because it was being delayed.

It's better that if no destination is set then the pointer can work
again immediately, but after a destination set has occured then the
pointer activation should be delayed.