### PR TITLE
fix(Pointer): switch off usage on pointer off

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
@@ -46,6 +46,8 @@ namespace VRTK
 
         private float activateDelayTimer = 0f;
 
+        private VRTK_InteractableObject interactableObject = null;
+
         public virtual void setPlayAreaCursorCollision(bool state)
         {
             if (handlePlayAreaCursorCollisions)
@@ -179,7 +181,7 @@ namespace VRTK
 
             OnDestinationMarkerEnter(SetDestinationMarkerEvent(pointerContactDistance, pointerContactTarget, destinationPosition, controllerIndex));
 
-            var interactableObject = pointerContactTarget.GetComponent<VRTK_InteractableObject>();
+            interactableObject = pointerContactTarget.GetComponent<VRTK_InteractableObject>();
             if (interactableObject && interactableObject.pointerActivatesUseAction && interactableObject.holdButtonToUse)
             {
                 interactableObject.StartUsing(gameObject);
@@ -195,7 +197,6 @@ namespace VRTK
 
             OnDestinationMarkerExit(SetDestinationMarkerEvent(pointerContactDistance, pointerContactTarget, destinationPosition, controllerIndex));
 
-            var interactableObject = pointerContactTarget.GetComponent<VRTK_InteractableObject>();
             if (interactableObject && interactableObject.pointerActivatesUseAction && interactableObject.holdButtonToUse)
             {
                 interactableObject.StopUsing(gameObject);
@@ -239,6 +240,10 @@ namespace VRTK
         {
             var playAreaState = (showPlayAreaCursor ? state : false);
             playAreaCursor.gameObject.SetActive(playAreaState);
+            if (!state && interactableObject && interactableObject.pointerActivatesUseAction && interactableObject.holdButtonToUse && interactableObject.IsUsing())
+            {
+                interactableObject.StopUsing(this.gameObject);
+            }
         }
 
         protected virtual void SetPointerMaterial()


### PR DESCRIPTION
If pointerActivatesUseAction is true in VRTK_InteractableObject, after
pointing at the object with the pointer, the object continues to be used
also when the pointer is switched off.

Add a check in VRTK_WordPointer.TogglePointer() to switch off the
object usage if the pointer is switched off (add also a reference to the
object as private class member to keep track of the pointed object).