### PR TITLE
chore(Code): remove unneeded scope references

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractTouch.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractTouch.cs
@@ -8,7 +8,6 @@
 namespace VRTK
 {
     using UnityEngine;
-    using System.Collections;
 
     public struct ObjectInteractEventArgs
     {
@@ -109,8 +108,8 @@ namespace VRTK
                 return;
             }
 
-            Utilities.SetPlayerObject(this.gameObject, VRTK_PlayerObject.ObjectTypes.Controller);
-            CreateTouchCollider(this.gameObject);
+            Utilities.SetPlayerObject(gameObject, VRTK_PlayerObject.ObjectTypes.Controller);
+            CreateTouchCollider(gameObject);
             CreateControllerRigidBody();
             triggerRumble = false;
         }
@@ -153,7 +152,7 @@ namespace VRTK
 
                 var touchedObjectScript = touchedObject.GetComponent<VRTK_InteractableObject>();
 
-                if (!touchedObjectScript.IsValidInteractableController(this.gameObject, touchedObjectScript.allowedTouchControllers))
+                if (!touchedObjectScript.IsValidInteractableController(gameObject, touchedObjectScript.allowedTouchControllers))
                 {
                     touchedObject = null;
                     return;
@@ -161,7 +160,7 @@ namespace VRTK
 
                 OnControllerTouchInteractableObject(SetControllerInteractEvent(touchedObject));
                 touchedObjectScript.ToggleHighlight(true, globalTouchHighlightColor);
-                touchedObjectScript.StartTouching(this.gameObject);
+                touchedObjectScript.StartTouching(gameObject);
 
                 if (controllerActions.IsControllerVisible() && hideControllerOnTouch)
                 {
@@ -216,7 +215,7 @@ namespace VRTK
 
                 OnControllerUntouchInteractableObject(SetControllerInteractEvent(untouched.gameObject));
                 untouched.GetComponent<VRTK_InteractableObject>().ToggleHighlight(false);
-                untouched.GetComponent<VRTK_InteractableObject>().StopTouching(this.gameObject);
+                untouched.GetComponent<VRTK_InteractableObject>().StopTouching(gameObject);
             }
 
             if (hideControllerOnTouch)
@@ -228,8 +227,8 @@ namespace VRTK
 
         private void CreateTouchCollider(GameObject obj)
         {
-            var collider = this.GetComponent<Collider>();
-            if(collider == null)
+            var collider = GetComponent<Collider>();
+            if (collider == null)
             {
                 var genCollider = obj.AddComponent<SphereCollider>();
                 genCollider.radius = 0.06f;
@@ -259,7 +258,8 @@ namespace VRTK
             if (customRigidbodyObject != null)
             {
                 controllerRigidBodyObject = customRigidbodyObject;
-            } else
+            }
+            else
             {
                 controllerRigidBodyObject = new GameObject();
                 CreateBoxCollider(controllerRigidBodyObject, new Vector3(0f, -0.01f, -0.098f), new Vector3(0.04f, 0.025f, 0.15f));
@@ -276,8 +276,8 @@ namespace VRTK
 
             var controllerRB = controllerRigidBodyObject.GetComponent<Rigidbody>();
 
-            controllerRigidBodyObject.name = string.Format("[{0}]_RigidBody_Holder", this.gameObject.name);
-            controllerRigidBodyObject.transform.parent = this.transform;
+            controllerRigidBodyObject.name = string.Format("[{0}]_RigidBody_Holder", gameObject.name);
+            controllerRigidBodyObject.transform.parent = transform;
             controllerRigidBodyObject.transform.localPosition = Vector3.zero;
 
             controllerRB.useGravity = false;

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractableObject.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractableObject.cs
@@ -11,9 +11,7 @@
 namespace VRTK
 {
     using UnityEngine;
-    using System.Collections;
     using System.Collections.Generic;
-
 
     public struct InteractableObjectEventArgs
     {
@@ -241,11 +239,11 @@ namespace VRTK
         {
             if (onGrabCollisionDelay > 0f)
             {
-                if (this.GetComponent<Rigidbody>())
+                if (GetComponent<Rigidbody>())
                 {
-                    this.GetComponent<Rigidbody>().detectCollisions = false;
+                    GetComponent<Rigidbody>().detectCollisions = false;
                 }
-                foreach (Rigidbody rb in this.GetComponentsInChildren<Rigidbody>())
+                foreach (Rigidbody rb in GetComponentsInChildren<Rigidbody>())
                 {
                     rb.detectCollisions = false;
                 }
@@ -260,10 +258,10 @@ namespace VRTK
 
         public void ZeroVelocity()
         {
-            if (this.GetComponent<Rigidbody>())
+            if (GetComponent<Rigidbody>())
             {
-                this.GetComponent<Rigidbody>().velocity = Vector3.zero;
-                this.GetComponent<Rigidbody>().angularVelocity = Vector3.zero;
+                GetComponent<Rigidbody>().velocity = Vector3.zero;
+                GetComponent<Rigidbody>().angularVelocity = Vector3.zero;
             }
         }
 
@@ -271,7 +269,7 @@ namespace VRTK
         {
             if (grabbingObject == null)
             {
-                previousParent = this.transform.parent;
+                previousParent = transform.parent;
                 previousKinematicState = rb.isKinematic;
             }
         }
@@ -324,7 +322,7 @@ namespace VRTK
 
         public void RegisterTeleporters()
         {
-            foreach (var teleporter in GameObject.FindObjectsOfType<VRTK_BasicTeleport>())
+            foreach (var teleporter in FindObjectsOfType<VRTK_BasicTeleport>())
             {
                 teleporter.Teleported += new TeleportEventHandler(OnTeleported);
             }
@@ -332,7 +330,7 @@ namespace VRTK
 
         protected virtual void Awake()
         {
-            rb = this.GetComponent<Rigidbody>();
+            rb = GetComponent<Rigidbody>();
 
             // If there is no rigid body, add one and set it to 'kinematic'.
             if (!rb)
@@ -351,7 +349,7 @@ namespace VRTK
 
         protected virtual void Update()
         {
-            if (!this.gameObject.activeInHierarchy)
+            if (!gameObject.activeInHierarchy)
             {
                 ForceStopInteracting();
             }
@@ -390,9 +388,9 @@ namespace VRTK
 
         protected virtual void LoadPreviousState()
         {
-            if (this.gameObject.activeInHierarchy)
+            if (gameObject.activeInHierarchy)
             {
-                this.transform.parent = previousParent;
+                transform.parent = previousParent;
             }
             rb.isKinematic = previousKinematicState;
             if (!isSwappable)
@@ -411,11 +409,11 @@ namespace VRTK
 
         private void UnpauseCollisions()
         {
-            if (this.GetComponent<Rigidbody>())
+            if (GetComponent<Rigidbody>())
             {
-                this.GetComponent<Rigidbody>().detectCollisions = true;
+                GetComponent<Rigidbody>().detectCollisions = true;
             }
-            foreach (Rigidbody rb in this.GetComponentsInChildren<Rigidbody>())
+            foreach (Rigidbody rb in GetComponentsInChildren<Rigidbody>())
             {
                 rb.detectCollisions = true;
             }
@@ -467,7 +465,7 @@ namespace VRTK
         {
             if (trackPoint)
             {
-                float distance = Vector3.Distance(trackPoint.position, this.transform.position);
+                float distance = Vector3.Distance(trackPoint.position, transform.position);
                 if (distance > (detachThreshold / 1000))
                 {
                     ForceReleaseGrab();
@@ -487,14 +485,15 @@ namespace VRTK
 
             if (AttachIsTrackObject() && precisionSnap)
             {
-                trackPoint = new GameObject(string.Format("[{0}]TrackObject_PrecisionSnap_AttachPoint", this.gameObject.name)).transform;
+                trackPoint = new GameObject(string.Format("[{0}]TrackObject_PrecisionSnap_AttachPoint", gameObject.name)).transform;
                 trackPoint.parent = point.transform;
                 customTrackPoint = true;
-                if(grabAttachMechanic == GrabAttachType.Track_Object)
+                if (grabAttachMechanic == GrabAttachType.Track_Object)
                 {
-                    trackPoint.position = this.transform.position;
-                    trackPoint.rotation = this.transform.rotation;
-                } else
+                    trackPoint.position = transform.position;
+                    trackPoint.rotation = transform.rotation;
+                }
+                else
                 {
                     trackPoint.position = controllerPoint.position;
                     trackPoint.rotation = controllerPoint.rotation;
@@ -507,7 +506,7 @@ namespace VRTK
             }
 
             originalControllerAttachPoint = new GameObject(string.Format("[{0}]Original_Controller_AttachPoint", grabbingObject.name)).transform;
-            originalControllerAttachPoint.parent = this.transform;
+            originalControllerAttachPoint.parent = transform;
             originalControllerAttachPoint.position = trackPoint.position;
             originalControllerAttachPoint.rotation = trackPoint.rotation;
         }
@@ -551,8 +550,8 @@ namespace VRTK
             }
             else
             {
-                rotationDelta = trackPoint.rotation * Quaternion.Inverse(this.transform.rotation);
-                positionDelta = trackPoint.position - this.transform.position;
+                rotationDelta = trackPoint.rotation * Quaternion.Inverse(transform.rotation);
+                positionDelta = trackPoint.position - transform.position;
             }
 
             rotationDelta.ToAngleAxis(out angle, out axis);
@@ -573,7 +572,7 @@ namespace VRTK
         {
             if (AttachIsTrackObject() && trackPoint)
             {
-                this.transform.position = grabbingObject.transform.position;
+                transform.position = grabbingObject.transform.position;
             }
         }
     }


### PR DESCRIPTION
While looking through the code of touch and interactable object I
found many references to 'this' which is not a common practice (they are
simply provided by the extended MonoBehaviour), clutters the code and
causes Visual Studio to highlight these as unneeded making the code
very colorful.