### PR TITLE
feat(Testing): add movement simulator resolves #262

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_Simulator.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_Simulator.cs
@@ -1,0 +1,109 @@
+﻿namespace VRTK
+{
+    using UnityEngine;
+
+    public class VRTK_Simulator : MonoBehaviour
+    {
+        [System.Serializable]
+        public class Keys
+        {
+            public KeyCode forward = KeyCode.W;
+            public KeyCode backward = KeyCode.S;
+            public KeyCode strafeLeft = KeyCode.A;
+            public KeyCode strafeRight = KeyCode.D;
+            public KeyCode left = KeyCode.Q;
+            public KeyCode right = KeyCode.E;
+            public KeyCode up = KeyCode.Y;
+            public KeyCode down = KeyCode.C;
+            public KeyCode reset = KeyCode.X;
+        }
+        public Keys keys;
+        [Tooltip("Will deactivate the script if run in a build outside the editor.")]
+        public bool onlyInEditor = true;
+        public float stepSize = 0.05f;
+        [Tooltip("An optional game object marking the position and rotation at which the camera should be initially placed.")]
+        public Transform camStart;
+
+        private Transform cam;
+        private Vector3 initialPosition;
+        private Quaternion initialRotation;
+
+        void Start()
+        {
+            // don't run in builds outside the editor
+            if (onlyInEditor && !Application.isEditor)
+            {
+                enabled = false;
+                return;
+            }
+
+            cam = GetComponentInChildren<Camera>().transform;
+            if (!cam)
+            {
+                Debug.LogWarning("Could not find camera. Simulator deactivated.");
+                enabled = false;
+                return;
+            }
+
+            if (camStart && camStart.gameObject.activeInHierarchy)
+            {
+                transform.position = camStart.position;
+                transform.rotation = camStart.rotation;
+            }
+
+            initialPosition = transform.position;
+            initialRotation = transform.rotation;
+        }
+
+        void Update()
+        {
+            Vector3 movDir = Vector3.zero;
+            Vector3 rotDir = Vector3.zero;
+
+            if (Input.GetKey(keys.forward))
+            {
+                movDir = overwriteY(cam.forward, 0);
+            }
+            else if (Input.GetKey(keys.backward))
+            {
+                movDir = overwriteY(cam.forward, 0) * -1;
+            }
+            else if (Input.GetKey(keys.strafeLeft))
+            {
+                movDir = overwriteY(cam.right, 0);
+            }
+            else if (Input.GetKey(keys.strafeRight))
+            {
+                movDir = overwriteY(cam.right, 0) * -1;
+            }
+            else if (Input.GetKey(keys.up))
+            {
+                movDir = new Vector3(0, 1, 0);
+            }
+            else if (Input.GetKey(keys.down))
+            {
+                movDir = new Vector3(0, -1, 0);
+            }
+            else if (Input.GetKey(keys.left))
+            {
+                rotDir = new Vector3(0, 1, 0);
+            }
+            else if (Input.GetKey(keys.right))
+            {
+                rotDir = new Vector3(0, -1, 0);
+            }
+            else if (Input.GetKey(keys.reset))
+            {
+                transform.position = initialPosition;
+                transform.rotation = initialRotation;
+            }
+            transform.Translate(movDir * stepSize);
+            transform.Rotate(rotDir);
+        }
+
+        private Vector3 overwriteY(Vector3 vector, float value)
+        {
+            return new Vector3(vector.x, value, vector.z);
+        }
+    }
+}

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_Simulator.cs.meta
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_Simulator.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: a5761c48d9dd95c41b36acc5584d7803
+timeCreated: 1469620307
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -183,6 +183,7 @@ This directory contains all of the toolkit scripts that add VR functionality to 
  * [VRTK_InteractGrab](#grabbing-interactable-objects-vrtk_interactgrab)
  * [VRTK_InteractUse](#using-interactable-objects-vrtk_interactuse)
  * [VRTK_ObjectAutoGrab](#auto-grabbing-interactable-objects-vrtk_objectautograb)
+ * [VRTK_Simulator](#simulator-vrtk_simulator)
 
 ---
 
@@ -1471,6 +1472,23 @@ The Object Auto Grab script is attached to a Controller object within the `[Came
 ### Example
 
 `SteamVR_Unity_Toolkit/Examples/026_Controller_ForceHoldObject` shows how to automatically grab a sword to each controller and also prevents the swords from being dropped so they are permanently attached to the user's controllers.
+
+---
+
+## Testing Without Using The Headset (VRTK_Simulator)
+
+### Overview
+
+To test a scene it is often necessary to use the headset to move to a location. This increases turn-around times and can become cumbersome. The simulator allows navigating through the scene using the keyboard instead, without the need to put on the headset. One can then move around (also through walls) while looking at the monitor and still use the controllers to interact.
+
+The Simulator script is attached to the `[CameraRig]` prefab. Supported movements are: forward, backward, strafe left, strafe right, turn left, turn right, up, down.
+
+### Inspector Parameters
+
+  * **Keys:** Per default the keys on the left-hand side of the keyboard are used (WASD). They can be individually set as needed. The reset key brings the camera to its initial location.
+  * **Only In Editor:** Typically the simulator should be turned off when not testing anymore. This option will do this automatically when outside the editor.
+  * **Step Size:** Depending on the scale of the world the step size can be defined to increase or decrease movement speed.
+  * **Cam Start:** It can be very handy to start at a certain location instead of having to walk/teleport there first. A good workflow can be to use the keys to navigate in the scene one time, then copy the transform of the `[CameraRig]`, stop the scene and paste the values to an empty game object that is then assigned here. To start at the original position again it is enough to deactivate the game object.
 
 ---
 


### PR DESCRIPTION
For many trivial tests one still has to put on the headset in order to
move to the right spot. This increases turn-around times. This script
can be put onto the camera rig and will then allow movement through
the scene using keys. Once at the desired location the controllers can
be used to interact while looking at the monitor.

Supported so far are move, strafe, rotate and up/down. Being an early
version this is only tested in one context so far and especially after
rotating the move directions are inverted currently. These are all
things to look at in future versions. Help always welcome.