### PR TITLE
fix(Interaction): prevent controller swap breaking use functionality - resolves #343

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractUse.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractUse.cs
@@ -57,6 +57,14 @@ namespace VRTK
             }
         }
 
+        public void ForceResetUsing()
+        {
+            if (usingObject != null)
+            {
+                UnuseInteractedObject(false);
+            }
+        }
+
         private void Awake()
         {
             if (GetComponent<VRTK_InteractTouch>() == null)
@@ -147,17 +155,23 @@ namespace VRTK
             }
         }
 
-        private void UnuseInteractedObject()
+        private void UnuseInteractedObject(bool completeStop)
         {
             if (usingObject != null)
             {
                 OnControllerUnuseInteractableObject(interactTouch.SetControllerInteractEvent(usingObject));
-                usingObject.GetComponent<VRTK_InteractableObject>().StopUsing(gameObject);
+                if (completeStop)
+                {
+                    usingObject.GetComponent<VRTK_InteractableObject>().StopUsing(gameObject);
+                }
                 if (hideControllerOnUse)
                 {
                     controllerActions.ToggleControllerModel(true, usingObject);
                 }
-                usingObject.GetComponent<VRTK_InteractableObject>().ToggleHighlight(false);
+                if (completeStop)
+                {
+                    usingObject.GetComponent<VRTK_InteractableObject>().ToggleHighlight(false);
+                }
                 usingObject = null;
             }
         }
@@ -174,7 +188,7 @@ namespace VRTK
         private void StopUsing()
         {
             SetObjectUsingState(usingObject, 0);
-            UnuseInteractedObject();
+            UnuseInteractedObject(true);
         }
 
         private void DoStartUseObject(object sender, ControllerInteractionEventArgs e)

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractableObject.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractableObject.cs
@@ -175,6 +175,7 @@ namespace VRTK
         {
             OnInteractableObjectUntouched(SetInteractableObjectEvent(previousTouchingObject));
             touchingObject = null;
+            StopUsingOnControllerChange(previousTouchingObject);
         }
 
         public virtual void Grabbed(GameObject currentGrabbingObject)
@@ -198,6 +199,23 @@ namespace VRTK
             grabbedSnapHandle = null;
             grabbingObject = null;
             LoadPreviousState();
+            StopUsingOnControllerChange(previousGrabbingObject);
+        }
+
+        private void StopUsingOnControllerChange(GameObject previousController)
+        {
+            var usingObject = previousController.GetComponent<VRTK_InteractUse>();
+            if (usingObject)
+            {
+                if (holdButtonToUse)
+                {
+                    usingObject.ForceStopUsing();
+                }
+                else
+                {
+                    usingObject.ForceResetUsing();
+                }
+            }
         }
 
         public virtual void StartUsing(GameObject currentUsingObject)

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1446,7 +1446,18 @@ The GetUsingObject method returns the current object being used by the controlle
   * Returns
    * _none_
 
-The ForceStopUsing method will force the controller to stop using the currently touched object.
+The ForceStopUsing method will force the controller to stop using the currently touched object and will also stop the object's using action.
+
+#### ForceResetUsing/0
+
+  > `public void ForceResetUsing()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * _none_
+
+The ForceResetUsing will force the controller to stop using the currently touched object but the object will continue with it's existing using action.
 
 ### Example
 


### PR DESCRIPTION
Previously, when using an object and swapping controllers (either
grab or touch state) the use state on the object would not be reset
correctly and therefore the previous using controller would still
be considered the active use controller.

This fix ensures that when a controller stops touching or grabbing
an object, that the use state on the controller is also reset to
no longer using the object.