### PR TITLE
feat(Interaction): override controller hide + use only if grabbed

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Examples/036_Controller_CustomCompoundPointer.unity
+++ b/Assets/SteamVR_Unity_Toolkit/Examples/036_Controller_CustomCompoundPointer.unity
@@ -471,6 +471,38 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 70459821}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!21 &76835181
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Sprites/Default
+  m_Shader: {fileID: 10753, guid: 0000000000000000e000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 5
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  m_SavedProperties:
+    serializedVersion: 2
+    m_TexEnvs:
+      data:
+        first:
+          name: _MainTex
+        second:
+          m_Texture: {fileID: 0}
+          m_Scale: {x: 1, y: 1}
+          m_Offset: {x: 0, y: 0}
+    m_Floats:
+      data:
+        first:
+          name: PixelSnap
+        second: 0
+    m_Colors:
+      data:
+        first:
+          name: _Color
+        second: {r: 1, g: 1, b: 1, a: 1}
 --- !u!1 &154582535
 GameObject:
   m_ObjectHideFlags: 0
@@ -2705,6 +2737,7 @@ MonoBehaviour:
   touchHighlightColor: {r: 0, g: 0, b: 0, a: 0}
   rumbleOnTouch: {x: 0, y: 0}
   allowedTouchControllers: 0
+  hideControllerOnTouch: 0
   isGrabbable: 1
   isDroppable: 1
   isSwappable: 1
@@ -2714,6 +2747,7 @@ MonoBehaviour:
   precisionSnap: 1
   rightSnapHandle: {fileID: 0}
   leftSnapHandle: {fileID: 0}
+  hideControllerOnGrab: 0
   grabAttachMechanic: 0
   detachThreshold: 500
   springJointStrength: 500
@@ -2721,10 +2755,12 @@ MonoBehaviour:
   throwMultiplier: 2
   onGrabCollisionDelay: 0
   isUsable: 1
+  useOnlyIfGrabbed: 1
   holdButtonToUse: 1
   pointerActivatesUseAction: 1
   rumbleOnUse: {x: 0, y: 0}
   allowedUseControllers: 0
+  hideControllerOnUse: 1
   idleSpinSpeed: 30
   activeSpinSpeed: 360
   rotatingObject: {fileID: 400710284}
@@ -3618,38 +3654,6 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1385462518}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!21 &1413835603
-Material:
-  serializedVersion: 6
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_Name: Sprites/Default
-  m_Shader: {fileID: 10753, guid: 0000000000000000e000000000000000, type: 0}
-  m_ShaderKeywords: 
-  m_LightmapFlags: 5
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  m_SavedProperties:
-    serializedVersion: 2
-    m_TexEnvs:
-      data:
-        first:
-          name: _MainTex
-        second:
-          m_Texture: {fileID: 0}
-          m_Scale: {x: 1, y: 1}
-          m_Offset: {x: 0, y: 0}
-    m_Floats:
-      data:
-        first:
-          name: PixelSnap
-        second: 0
-    m_Colors:
-      data:
-        first:
-          name: _Color
-        second: {r: 1, g: 1, b: 1, a: 1}
 --- !u!1 &1441429307
 GameObject:
   m_ObjectHideFlags: 0
@@ -3969,6 +3973,7 @@ MonoBehaviour:
   touchHighlightColor: {r: 0, g: 0, b: 0, a: 0}
   rumbleOnTouch: {x: 0, y: 0}
   allowedTouchControllers: 0
+  hideControllerOnTouch: 0
   isGrabbable: 0
   isDroppable: 0
   isSwappable: 0
@@ -3978,6 +3983,7 @@ MonoBehaviour:
   precisionSnap: 0
   rightSnapHandle: {fileID: 0}
   leftSnapHandle: {fileID: 0}
+  hideControllerOnGrab: 0
   grabAttachMechanic: 0
   detachThreshold: 500
   springJointStrength: 500
@@ -3985,10 +3991,12 @@ MonoBehaviour:
   throwMultiplier: 1
   onGrabCollisionDelay: 0
   isUsable: 1
+  useOnlyIfGrabbed: 0
   holdButtonToUse: 1
   pointerActivatesUseAction: 1
   rumbleOnUse: {x: 0, y: 0}
   allowedUseControllers: 0
+  hideControllerOnUse: 0
   idleSpinSpeed: 30
   activeSpinSpeed: 360
   rotatingObject: {fileID: 804905403}
@@ -4256,7 +4264,7 @@ MeshFilter:
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1665097736}
-  m_Mesh: {fileID: 1981755073}
+  m_Mesh: {fileID: 1840716646}
 --- !u!23 &1665097740
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -4268,7 +4276,7 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_Materials:
-  - {fileID: 1413835603}
+  - {fileID: 76835181}
   m_SubsetIndices: 
   m_StaticBatchRoot: {fileID: 0}
   m_UseLightProbes: 0
@@ -4628,6 +4636,134 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1793155199}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!43 &1840716646
+Mesh:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: 
+  serializedVersion: 8
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 24
+    topology: 0
+    firstVertex: 0
+    vertexCount: 8
+    localAABB:
+      m_Center: {x: 0, y: 0.01, z: 0}
+      m_Extent: {x: 0.6500001, y: 0, z: 0.6500001}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexBuffer: 000004000100010004000500010005000200020005000600020006000300030006000700030007000000000007000400
+  m_Skin: []
+  m_VertexData:
+    m_CurrentChannels: 13
+    m_VertexCount: 8
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 28
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 288
+    _typelessdata: 0200003f0ad7233c020000bf000000000000803f0000803f0000803f0000000000000000020000bf0ad7233c020000bf000000000000803f0000803f0000803f0000803f00000000020000bf0ad7233c0200003f000000000000803f0000803f0000803f00000000000000000200003f0ad7233c0200003f000000000000803f0000803f0000803f0000803f000000006866263f0ad7233c686626bf000000000000803f0000803f00000000000000000000803f686626bf0ad7233c686626bf000000000000803f0000803f000000000000803f0000803f686626bf0ad7233c6866263f000000000000803f0000803f00000000000000000000803f6866263f0ad7233c6866263f000000000000803f0000803f000000000000803f0000803f
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0, y: 0.01, z: 0}
+    m_Extent: {x: 0.6500001, y: 0, z: 0.6500001}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshOptimized: 0
 --- !u!1 &1893873117
 GameObject:
   m_ObjectHideFlags: 0
@@ -6473,6 +6609,7 @@ MonoBehaviour:
   touchHighlightColor: {r: 0, g: 0, b: 0, a: 0}
   rumbleOnTouch: {x: 0, y: 0}
   allowedTouchControllers: 0
+  hideControllerOnTouch: 0
   isGrabbable: 0
   isDroppable: 0
   isSwappable: 0
@@ -6482,6 +6619,7 @@ MonoBehaviour:
   precisionSnap: 0
   rightSnapHandle: {fileID: 0}
   leftSnapHandle: {fileID: 0}
+  hideControllerOnGrab: 0
   grabAttachMechanic: 0
   detachThreshold: 500
   springJointStrength: 500
@@ -6489,10 +6627,12 @@ MonoBehaviour:
   throwMultiplier: 1
   onGrabCollisionDelay: 0
   isUsable: 1
+  useOnlyIfGrabbed: 0
   holdButtonToUse: 1
   pointerActivatesUseAction: 1
   rumbleOnUse: {x: 0, y: 0}
   allowedUseControllers: 0
+  hideControllerOnUse: 0
   idleSpinSpeed: 30
   activeSpinSpeed: 360
   rotatingObject: {fileID: 455226068}
@@ -6549,134 +6689,6 @@ Transform:
   - {fileID: 1640468214}
   m_Father: {fileID: 455500613}
   m_RootOrder: 8
---- !u!43 &1981755073
-Mesh:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_Name: 
-  serializedVersion: 8
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 24
-    topology: 0
-    firstVertex: 0
-    vertexCount: 8
-    localAABB:
-      m_Center: {x: 0, y: 0.01, z: 0}
-      m_Extent: {x: 0.6500001, y: 0, z: 0.6500001}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexBuffer: 000004000100010004000500010005000200020005000600020006000300030006000700030007000000000007000400
-  m_Skin: []
-  m_VertexData:
-    m_CurrentChannels: 13
-    m_VertexCount: 8
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 28
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 288
-    _typelessdata: 0200003f0ad7233c020000bf000000000000803f0000803f0000803f0000000000000000020000bf0ad7233c020000bf000000000000803f0000803f0000803f0000803f00000000020000bf0ad7233c0200003f000000000000803f0000803f0000803f00000000000000000200003f0ad7233c0200003f000000000000803f0000803f0000803f0000803f000000006866263f0ad7233c686626bf000000000000803f0000803f00000000000000000000803f686626bf0ad7233c686626bf000000000000803f0000803f000000000000803f0000803f686626bf0ad7233c6866263f000000000000803f0000803f00000000000000000000803f6866263f0ad7233c6866263f000000000000803f0000803f000000000000803f0000803f
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 0, y: 0.01, z: 0}
-    m_Extent: {x: 0.6500001, y: 0, z: 0.6500001}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshOptimized: 0
 --- !u!1 &1982041728
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
@@ -177,7 +177,9 @@ namespace VRTK
             OnDestinationMarkerEnter(SetDestinationMarkerEvent(pointerContactDistance, pointerContactTarget, destinationPosition, controllerIndex));
 
             interactableObject = pointerContactTarget.GetComponent<VRTK_InteractableObject>();
-            if (interactableObject && interactableObject.pointerActivatesUseAction && interactableObject.holdButtonToUse)
+            bool cannotUseBecauseNotGrabbed = (interactableObject && interactableObject.useOnlyIfGrabbed && !interactableObject.IsGrabbed());
+
+            if (interactableObject && interactableObject.pointerActivatesUseAction && interactableObject.holdButtonToUse && !cannotUseBecauseNotGrabbed)
             {
                 interactableObject.StartUsing(gameObject);
             }

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractGrab.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractGrab.cs
@@ -30,6 +30,7 @@ namespace VRTK
 
         private Joint controllerAttachJoint;
         private GameObject grabbedObject = null;
+        private bool updatedHideControllerOnGrab = false;
 
         private SteamVR_TrackedObject trackedController;
         private VRTK_InteractTouch interactTouch;
@@ -328,9 +329,10 @@ namespace VRTK
                 {
                     grabbedObjectScript.ToggleKinematic(true);
                 }
+                updatedHideControllerOnGrab = grabbedObjectScript.CheckHideMode(hideControllerOnGrab, grabbedObjectScript.hideControllerOnGrab );
             }
 
-            if (hideControllerOnGrab)
+            if (updatedHideControllerOnGrab)
             {
                 Invoke("HideController", hideControllerDelay);
             }
@@ -374,7 +376,7 @@ namespace VRTK
                 grabbedObject.GetComponent<VRTK_InteractableObject>().ToggleHighlight(false);
             }
 
-            if (hideControllerOnGrab)
+            if (updatedHideControllerOnGrab)
             {
                 controllerActions.ToggleControllerModel(true, grabbedObject);
             }

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractTouch.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractTouch.cs
@@ -30,6 +30,7 @@ namespace VRTK
 
         private GameObject touchedObject = null;
         private GameObject lastTouchedObject = null;
+        private bool updatedHideControllerOnTouch = false;
 
         private SteamVR_TrackedObject trackedController;
         private VRTK_ControllerActions controllerActions;
@@ -178,11 +179,12 @@ namespace VRTK
                     return;
                 }
 
+                updatedHideControllerOnTouch = touchedObjectScript.CheckHideMode(hideControllerOnTouch, touchedObjectScript.hideControllerOnTouch);
                 OnControllerTouchInteractableObject(SetControllerInteractEvent(touchedObject));
                 touchedObjectScript.ToggleHighlight(true, globalTouchHighlightColor);
                 touchedObjectScript.StartTouching(gameObject);
 
-                if (controllerActions.IsControllerVisible() && hideControllerOnTouch)
+                if (controllerActions.IsControllerVisible() && updatedHideControllerOnTouch)
                 {
                     Invoke("HideController", hideControllerDelay);
                 }
@@ -238,7 +240,7 @@ namespace VRTK
                 untouched.GetComponent<VRTK_InteractableObject>().StopTouching(gameObject);
             }
 
-            if (hideControllerOnTouch)
+            if (updatedHideControllerOnTouch)
             {
                 controllerActions.ToggleControllerModel(true, touchedObject);
             }

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractUse.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractUse.cs
@@ -24,9 +24,10 @@ namespace VRTK
         public event ObjectInteractEventHandler ControllerUseInteractableObject;
         public event ObjectInteractEventHandler ControllerUnuseInteractableObject;
 
-        GameObject usingObject = null;
-        VRTK_InteractTouch interactTouch;
-        VRTK_ControllerActions controllerActions;
+        private GameObject usingObject = null;
+        private VRTK_InteractTouch interactTouch;
+        private VRTK_ControllerActions controllerActions;
+        private bool updatedHideControllerOnUse = false;
 
         public virtual void OnControllerUseInteractableObject(ObjectInteractEventArgs e)
         {
@@ -129,10 +130,11 @@ namespace VRTK
                     return;
                 }
 
+                updatedHideControllerOnUse = usingObjectScript.CheckHideMode(hideControllerOnUse, usingObjectScript.hideControllerOnUse);
                 OnControllerUseInteractableObject(interactTouch.SetControllerInteractEvent(usingObject));
                 usingObjectScript.StartUsing(gameObject);
 
-                if (hideControllerOnUse)
+                if (updatedHideControllerOnUse)
                 {
                     Invoke("HideController", hideControllerDelay);
                 }
@@ -164,7 +166,7 @@ namespace VRTK
                 {
                     usingObject.GetComponent<VRTK_InteractableObject>().StopUsing(gameObject);
                 }
-                if (hideControllerOnUse)
+                if (updatedHideControllerOnUse)
                 {
                     controllerActions.ToggleControllerModel(true, usingObject);
                 }
@@ -201,6 +203,13 @@ namespace VRTK
 
             if (touchedObject != null && interactTouch.IsObjectInteractable(touchedObject))
             {
+                var interactableObjectScript = touchedObject.GetComponent<VRTK_InteractableObject>();
+
+                if (interactableObjectScript.useOnlyIfGrabbed && !interactableObjectScript.IsGrabbed())
+                {
+                    return;
+                }
+
                 UseInteractedObject(touchedObject);
                 if (usingObject && !IsObjectHoldOnUse(usingObject))
                 {

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractableObject.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractableObject.cs
@@ -38,11 +38,19 @@ namespace VRTK
             Right_Only
         }
 
+        public enum ControllerHideMode
+        {
+            Default,
+            OverrideHide,
+            OverrideDontHide,
+        }
+
         [Header("Touch Interactions", order = 1)]
         public bool highlightOnTouch = false;
         public Color touchHighlightColor = Color.clear;
         public Vector2 rumbleOnTouch = Vector2.zero;
         public AllowedController allowedTouchControllers = AllowedController.Both;
+        public ControllerHideMode hideControllerOnTouch = ControllerHideMode.Default;
 
         [Header("Grab Interactions", order = 2)]
         public bool isGrabbable = false;
@@ -54,6 +62,7 @@ namespace VRTK
         public bool precisionSnap;
         public Transform rightSnapHandle;
         public Transform leftSnapHandle;
+        public ControllerHideMode hideControllerOnGrab = ControllerHideMode.Default;
 
         [Header("Grab Mechanics", order = 3)]
         public GrabAttachType grabAttachMechanic = GrabAttachType.Fixed_Joint;
@@ -65,10 +74,12 @@ namespace VRTK
 
         [Header("Use Interactions", order = 4)]
         public bool isUsable = false;
+        public bool useOnlyIfGrabbed = false;
         public bool holdButtonToUse = true;
         public bool pointerActivatesUseAction = false;
         public Vector2 rumbleOnUse = Vector2.zero;
         public AllowedController allowedUseControllers = AllowedController.Both;
+        public ControllerHideMode hideControllerOnUse = ControllerHideMode.Default;
 
         public event InteractableObjectEventHandler InteractableObjectTouched;
         public event InteractableObjectEventHandler InteractableObjectUntouched;
@@ -94,6 +105,19 @@ namespace VRTK
         private bool previousKinematicState;
         private bool previousIsGrabbable;
         private bool forcedDropped;
+
+        public bool CheckHideMode(bool defaultMode, ControllerHideMode overrideMode)
+        {
+            switch (overrideMode)
+            {
+                case VRTK_InteractableObject.ControllerHideMode.OverrideDontHide:
+                    return false;
+                case VRTK_InteractableObject.ControllerHideMode.OverrideHide:
+                    return true;
+            }
+            // default: do not change
+            return defaultMode;
+        }
 
         public virtual void OnInteractableObjectTouched(InteractableObjectEventArgs e)
         {

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -963,6 +963,10 @@ The basis of this script is to provide a simple mechanism for identifying object
    * `Both` means both controllers will register a touch.
    * `Left_Only` means only the left controller will register a touch.
    * `Right_Only` means only the right controller will register a touch.
+  * **Hide Controller On Touch:** Optionally override the controller setting (hide when touched):
+   * `Default` means using controller settings.
+   * `Override Hide` means hiding the controller when touched, overriding controller settings.
+   * `Override Dont Hide` means *not* hiding the controller when touched, overriding controller settings.
 
 #### Grab Interactions
   * **Is Grabbable:** Determines if the object can be grabbed.
@@ -977,6 +981,10 @@ The basis of this script is to provide a simple mechanism for identifying object
   * **Precision_Snap:** If this is checked then when the controller grabs the object, it will grab it with precision and pick it up at the particular point on the object the controller is touching.
   * **Right Snap Handle:** A Transform provided as an empty game object which must be the child of the item being grabbed and serves as an orientation point to rotate and position the grabbed item in relation to the right handed controller. If no Right Snap Handle is provided but a Left Snap Handle is provided, then the Left Snap Handle will be used in place. If no Snap Handle is provided then the object will be grabbed at it's central point.
   * **Left Snap Handle:** A Transform provided as an empty game object which must be the child of the item being grabbed and serves as an orientation point to rotate and position the grabbed item in relation to the left handed controller. If no Left Snap Handle is provided but a Right Snap Handle is provided, then the Right Snap Handle will be used in place. If no Snap Handle is provided then the object will be grabbed at it's central point.
+  * **Hide Controller On Grab:** Optionally override the controller setting (hide when grabbed):
+   * `Default` means using controller settings.
+   * `Override Hide` means hiding the controller when grabbed, overriding controller settings.
+   * `Override Dont Hide` means *not* hiding the controller when grabbed, overriding controller settings.
 
 #### Grab Mechanics
   * **Grab Attach Type:** This determines how the grabbed item will be attached to the controller when it is grabbed.
@@ -993,6 +1001,7 @@ The basis of this script is to provide a simple mechanism for identifying object
 
 #### Use Interactions
   * **Is Usable:** Determines if the object can be used.
+  * **Use Only If Grabbed:** If this is checked the object can be used only if it was grabbed before.
   * **Hold Button To Use:** If this is checked then the use button on the controller needs to be continually held down to keep using. If this is unchecked the the use button toggles the use action with one button press to start using and another to stop using.
   * **Pointer Activates Use Action:** If this is checked then when a World Pointer beam (projected from the controller) hits the interactable object, if the object has `Hold Button To Use` unchecked then whilst the pointer is over the object it will run it's `Using` method. If `Hold Button To Use` is unchecked then the `Using` method will be run when the pointer is deactivated. The world pointer will not throw the `Destination Set` event if it is affecting an interactable object with this setting checked as this prevents unwanted teleporting from happening when using an object with a pointer.
   * **Rumble On Use:** The haptic feedback on the controller can be triggered upon using the object, the `x` denotes the length of time, the `y` denotes the strength of the pulse. (x and y will be replaced in the future with a custom editor).
@@ -1000,6 +1009,10 @@ The basis of this script is to provide a simple mechanism for identifying object
    * `Both` means both controllers are allowed to use.
    * `Left_Only` means only the left controller is allowed to use.
    * `Right_Only` means only the right controller is allowed to use.
+  * **Hide Controller On Use:** Optionally override the controller setting (hide when used):
+   * `Default` means using controller settings.
+   * `Override Hide` means hiding the controller when using, overriding controller settings.
+   * `Override Dont Hide` means *not* hiding the controller when using, overriding controller settings.
 
 ### Class Events
 
@@ -1015,6 +1028,22 @@ The basis of this script is to provide a simple mechanism for identifying object
   * `GameObject interactingObject` - The object that is initiating the interaction (e.g. a controller)
 
 ### Class Methods
+
+#### CheckHideMode/2
+
+  > `public bool CheckHideMode(bool defaultMode, ControllerHideMode overrideMode)`
+
+  * Parameters
+   * `bool defaultMode` - The default setting of the controller (true=hide, false="don't hide").
+   * `ControllerHideMode overrideMode` - The override setting of the object.
+     * `Default` means using controller settings (returns `overrideMode`).
+     * `OverrideHide` means hiding the controller anyway (even if `defaultMode`is `true`).
+     * `OverrideDontHide` means *not* hiding the controller anyway (even if `defaultMode`is `false`).
+  * Returns
+   * `bool` - Returns `true` if the combination of `defaultMode` and `overrideMode` lead to "hide controller".
+
+The CheckHideMode method is a simple service method used only by some scripts (e.g. InteractTouch InteractGrab InteractUse) to calculate the "hide controller" condition according to the default controller settings and the interactive object override method.
+
 
 #### IsTouched/0
 


### PR DESCRIPTION
Add to Interactable Object a "Hide on touch/grab/use" option which
overrides the controller option (see issue #79 and #346).

Add to Interactable Object a "Use Only If Grabbed" option which can
prevent an object to be used if not grabbed (see issue #346).

Set "Hide Controller On Use" to "Override Hide" and checked
"Use Only If Grabbed" in the object "Usable Grabbable Sphere"
(script "Use Rotate") in the example scene
036_Controller_CustomCompoundPointer. The sphere can be used only if
grabbed and when it is used the grabbing controller disappears.