### PR TITLE
fix(ControllerEventsUI): fix bug with SteamVR keyboard and uipointer

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_ControllerEvents.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_ControllerEvents.cs
@@ -331,6 +331,12 @@
             device = SteamVR_Controller.Input((int)controllerIndex);
         }
 
+        private void OnDisable()
+        {
+            pointerPressed = false;
+            uiClickPressed = false;
+        }
+
         private float CalculateTouchpadAxisAngle(Vector2 axis)
         {
             float angle = Mathf.Atan2(axis.y, axis.x) * Mathf.Rad2Deg;


### PR DESCRIPTION
If SteamVR Keyboard is shown, SteamVR disables both controllers in the
scene. If the UIPointer is active whe the keyboard is opened (will happen if using the
UI, for example if input field is clicked), VRTK_ControllerEvents will
never change state  because controllers are disable. so UIPointer won't
act accordingly, This causes unwanted behaviours like interacting with the UI even if no Pointer
is active.