### PR TITLE
fix(ControllerEvents): ensure all events are released when disabled

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
@@ -117,6 +117,7 @@ namespace VRTK
 
         protected virtual void OnDisable()
         {
+            ToggleBeam(false);
             controller.AliasPointerOn -= new ControllerInteractionEventHandler(EnablePointerBeam);
             controller.AliasPointerOff -= new ControllerInteractionEventHandler(DisablePointerBeam);
             controller.AliasPointerSet -= new ControllerInteractionEventHandler(SetPointerDestination);

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_ControllerEvents.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_ControllerEvents.cs
@@ -429,6 +429,52 @@
                     vectorA.y.ToString("F" + axisFidelity) == vectorB.y.ToString("F" + axisFidelity));
         }
 
+        private void OnDisable()
+        {
+            if (triggerPressed)
+            {
+                OnTriggerReleased(SetButtonEvent(ref triggerPressed, false, 0f));
+                EmitAlias(ButtonAlias.Trigger, false, 0f, ref triggerPressed);
+            }
+
+            if (applicationMenuPressed)
+            {
+                OnApplicationMenuReleased(SetButtonEvent(ref applicationMenuPressed, false, 0f));
+                EmitAlias(ButtonAlias.Application_Menu, false, 0f, ref applicationMenuPressed);
+            }
+
+            if (gripPressed)
+            {
+                OnGripReleased(SetButtonEvent(ref gripPressed, false, 0f));
+                EmitAlias(ButtonAlias.Grip, false, 0f, ref gripPressed);
+            }
+
+            if (touchpadPressed)
+            {
+                OnTouchpadReleased(SetButtonEvent(ref touchpadPressed, false, 0f));
+                EmitAlias(ButtonAlias.Touchpad_Press, false, 0f, ref touchpadPressed);
+            }
+
+            if (touchpadTouched)
+            {
+                OnTouchpadTouchEnd(SetButtonEvent(ref touchpadTouched, false, 0f));
+                EmitAlias(ButtonAlias.Touchpad_Touch, false, 0f, ref touchpadTouched);
+            }
+
+            triggerAxisChanged = false;
+            touchpadAxisChanged = false;
+
+            controllerIndex = (uint)trackedController.index;
+            device = SteamVR_Controller.Input((int)controllerIndex);
+
+            Vector2 currentTriggerAxis = device.GetAxis(Valve.VR.EVRButtonId.k_EButton_SteamVR_Trigger);
+            Vector2 currentTouchpadAxis = device.GetAxis();
+
+            // Save current touch and trigger settings to detect next change.
+            touchpadAxis = new Vector2(currentTouchpadAxis.x, currentTouchpadAxis.y);
+            triggerAxis = new Vector2(currentTriggerAxis.x, currentTriggerAxis.y);
+        }
+
         private void Update()
         {
             controllerIndex = (uint)trackedController.index;


### PR DESCRIPTION
There is an issue that controller events such as button presses can
become stuck in the on state if the controller is disabled whilst a
button is being held down. For example, bringing up the SteamVR
keyboard overlay will disable the Unity controller models but then
when the overlay is closed the initial state of the controller's
pressed buttons is not updated so buttons are reported as being
pressed even though they are no longer being pressed.

This fix is to ensure that upon the controller being disabled that
all buttons that are active will have their released state emitted.
This will put them back in a fresh state when the controller is
re-enabled. However, if a button is being held down it will need
to be released and re-held down again for the event to register.