### PR TITLE
fix(Interaction): ensure grab state is reset for tracked objects

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractGrab.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractGrab.cs
@@ -381,13 +381,13 @@ namespace VRTK
                 controllerActions.ToggleControllerModel(true, grabbedObject);
             }
 
+            grabEnabledState = 0;
             grabbedObject = null;
         }
 
         private void ReleaseObject(uint controllerIndex, bool withThrow)
         {
             UngrabInteractedObject(controllerIndex, withThrow);
-            grabEnabledState = 0;
         }
 
         private GameObject GetGrabbableObject()


### PR DESCRIPTION
Minor fix for tracked objects, the grab state was not being reset when
"Hold Button To Grab" was disabled after dropping an item. When grabbing it for a second time you have to hold the button despite it being disabled. Moving the state
reset into InitUngrabbedObject() fixes the issue as it is called no
matter which path is used to drop an item.