### PR TITLE
feat(Pointer): allow for pointer toggle with button presses resolves #213

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
@@ -26,7 +26,7 @@ namespace VRTK
         public bool handlePlayAreaCursorCollisions = false;
         public string ignoreTargetWithTagOrClass;
         public pointerVisibilityStates pointerVisibility = pointerVisibilityStates.On_When_Active;
-
+        public bool holdButtonToActivate = true;
         public float activateDelay = 0f;
 
         protected Vector3 destinationPosition;
@@ -45,6 +45,7 @@ namespace VRTK
         private bool destinationSetActive;
 
         private float activateDelayTimer = 0f;
+        private int beamEnabledState = 0;
 
         private VRTK_InteractableObject interactableObject = null;
 
@@ -203,7 +204,7 @@ namespace VRTK
 
         protected virtual void PointerSet()
         {
-            if (!enabled || !destinationSetActive || !pointerContactTarget || !CanActivate())
+            if (!enabled || !destinationSetActive || !pointerContactTarget || !CanActivate() || (!holdButtonToActivate && beamEnabledState != 0))
             {
                 return;
             }
@@ -279,6 +280,7 @@ namespace VRTK
 
         private void TurnOnBeam(uint index)
         {
+            beamEnabledState++;
             if (enabled && !isActive && CanActivate())
             {
                 setPlayAreaCursorCollision(false);
@@ -291,11 +293,12 @@ namespace VRTK
 
         private void TurnOffBeam(uint index)
         {
-            if (enabled && isActive)
+            if (enabled && isActive && (holdButtonToActivate || (!holdButtonToActivate && beamEnabledState >= 2)))
             {
                 controllerIndex = index;
                 TogglePointer(false);
                 isActive = false;
+                beamEnabledState = 0;
             }
         }
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -656,6 +656,7 @@ The Simple Pointer script can be attached to a Controller object within the `[Ca
    * `On_When_Active` only shows the pointer beam when the Pointer button on the controller is pressed.
    * `Always On` ensures the pointer beam is always visible but pressing the Pointer button on the controller initiates the destination set event.
    * `Always Off` ensures the pointer beam is never visible but the destination point is still set and pressing the Pointer button on the controller still initiates the destination set event.
+  * **Hold Button To Activate:** If this is checked then the pointer beam will be activated on first press of the pointer alias button and will stay active until the pointer alias button is pressed again. The destination set event is emitted when the beam is deactivated on the second button press.
   * **Activate Delay:** The time in seconds to delay the pointer beam being able to be active again. Useful for preventing constant teleportation.
   * **Pointer Thickness:** The thickness and length of the beam can also be set on the script as well as the ability to toggle the sphere beam tip that is displayed at the end of the beam (to represent a cursor).
   * **Pointer Length:** The distance the beam will project before stopping.
@@ -697,6 +698,7 @@ The Bezier Pointer script can be attached to a Controller object within the `[Ca
    * `On_When_Active` only shows the pointer beam when the Pointer button on the controller is pressed.
    * `Always On` ensures the pointer beam is always visible but pressing the Pointer button on the controller initiates the destination set event.
    * `Always Off` ensures the pointer beam is never visible but the destination point is still set and pressing the Pointer button on the controller still initiates the destination set event.
+  * **Hold Button To Activate:** If this is checked then the pointer beam will be activated on first press of the pointer alias button and will stay active until the pointer alias button is pressed again. The destination set event is emitted when the beam is deactivated on the second button press.
   * **Activate Delay:** The time in seconds to delay the pointer beam being able to be active again. Useful for preventing constant teleportation.
   * **Pointer Length:** The length of the projected forward pointer beam, this is basically the distance able to point from the controller potiion.
   * **Pointer Density:** The number of items to render in the beam bezier curve. A high number here will most likely have a negative impact of game performance due to large number of rendered objects.
@@ -1978,6 +1980,7 @@ The play area collider does not work well with terrains as they are uneven and c
    * `On_When_Active` only shows the pointer beam when the Pointer button on the controller is pressed.
    * `Always On` ensures the pointer beam is always visible but pressing the Pointer button on the controller initiates the destination set event.
    * `Always Off` ensures the pointer beam is never visible but the destination point is still set and pressing the Pointer button on the controller still initiates the destination set event.
+  * **Hold Button To Activate:** If this is checked then the pointer beam will be activated on first press of the pointer alias button and will stay active until the pointer alias button is pressed again. The destination set event is emitted when the beam is deactivated on the second button press.
   * **Activate Delay:** The time in seconds to delay the pointer beam being able to be active again. Useful for preventing constant teleportation.
 
 ### Class Methods


### PR DESCRIPTION
With the new `Hold Button To Activate` inspector parameter, it's
possible to activate the pointer beam with one press of the pointer
alias and the pointer then stays active until the pointer alias button
is pressed again.