### PR TITLE
fix(UIPointer): get pointer id from specified controller

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_UIPointer.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_UIPointer.cs
@@ -76,12 +76,12 @@
 
         private void Start()
         {
-            ConfigureEventSystem();
-            ConfigureWorldCanvases();
             if (controller == null)
             {
                 controller = GetComponent<VRTK_ControllerEvents>();
             }
+            ConfigureEventSystem();
+            ConfigureWorldCanvases();
         }
 
         private void ConfigureEventSystem()
@@ -90,7 +90,7 @@
             var eventSystemInput = SetEventSystem(eventSystem);
 
             pointerEventData = new PointerEventData(eventSystem);
-            pointerEventData.pointerId = (int)GetComponent<SteamVR_TrackedObject>().index + 1000;
+            pointerEventData.pointerId = (int)controller.gameObject.GetComponent<SteamVR_TrackedObject>().index + 1000;
             eventSystemInput.pointers.Add(this);
         }
 


### PR DESCRIPTION
Previously, the UIPointer would attempt to assign the pointer id
based on the provision that a Tracked Object script was present on
the same component as the UIPointer script. This meant it could
only be applied to the controllers or the headset by default.

The pointer id is now determined by the index of the controller
passed to the UI Pointer and therefore the UI pointer can be
attached to any game object that can also emit a world pointer.