### PR TITLE
chore(events): ensure events are managed on enable and disable - resolves #350

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Examples/Resources/Scripts/VRTK_ControllerInteract_ListenerExample.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Examples/Resources/Scripts/VRTK_ControllerInteract_ListenerExample.cs
@@ -25,21 +25,33 @@ public class VRTK_ControllerInteract_ListenerExample : MonoBehaviour
 
     private void DoInteractTouch(object sender, ObjectInteractEventArgs e)
     {
-        DebugLogger(e.controllerIndex, "TOUCHING", e.target);
+        if(e.target)
+        {
+            DebugLogger(e.controllerIndex, "TOUCHING", e.target);
+        }
     }
 
     private void DoInteractUntouch(object sender, ObjectInteractEventArgs e)
     {
-        DebugLogger(e.controllerIndex, "NO LONGER TOUCHING", e.target);
+        if (e.target)
+        {
+            DebugLogger(e.controllerIndex, "NO LONGER TOUCHING", e.target);
+        }
     }
 
     private void DoInteractGrab(object sender, ObjectInteractEventArgs e)
     {
-        DebugLogger(e.controllerIndex, "GRABBING", e.target);
+        if (e.target)
+        {
+            DebugLogger(e.controllerIndex, "GRABBING", e.target);
+        }
     }
 
     private void DoInteractUngrab(object sender, ObjectInteractEventArgs e)
     {
-        DebugLogger(e.controllerIndex, "NO LONGER GRABBING", e.target);
+        if (e.target)
+        {
+            DebugLogger(e.controllerIndex, "NO LONGER GRABBING", e.target);
+        }
     }
 }

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
@@ -118,7 +118,12 @@ namespace VRTK
 
         protected virtual void OnDisable()
         {
-            ToggleBeam(false);
+            DisableBeam();
+            destinationSetActive = false;
+            pointerContactDistance = 0f;
+            pointerContactTarget = null;
+            destinationPosition = Vector3.zero;
+
             controller.AliasPointerOn -= new ControllerInteractionEventHandler(EnablePointerBeam);
             controller.AliasPointerOff -= new ControllerInteractionEventHandler(DisablePointerBeam);
             controller.AliasPointerSet -= new ControllerInteractionEventHandler(SetPointerDestination);
@@ -238,7 +243,10 @@ namespace VRTK
         protected virtual void TogglePointer(bool state)
         {
             var playAreaState = (showPlayAreaCursor ? state : false);
-            playAreaCursor.gameObject.SetActive(playAreaState);
+            if(playAreaCursor)
+            {
+                playAreaCursor.gameObject.SetActive(playAreaState);
+            }
             if (!state && interactableObject && interactableObject.pointerActivatesUseAction && interactableObject.holdButtonToUse && interactableObject.IsUsing())
             {
                 interactableObject.StopUsing(this.gameObject);
@@ -296,10 +304,15 @@ namespace VRTK
             if (enabled && isActive && (holdButtonToActivate || (!holdButtonToActivate && beamEnabledState >= 2)))
             {
                 controllerIndex = index;
-                TogglePointer(false);
-                isActive = false;
-                beamEnabledState = 0;
+                DisableBeam();
             }
+        }
+
+        private void DisableBeam()
+        {
+            TogglePointer(false);
+            isActive = false;
+            beamEnabledState = 0;
         }
 
         private void DrawPlayAreaCursorBoundary(int index, float left, float right, float top, float bottom, float thickness, Vector3 localPosition)

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/Helper/VRTK_EventSystemVRInput.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/Helper/VRTK_EventSystemVRInput.cs
@@ -18,7 +18,7 @@
         {
             foreach (var pointer in pointers)
             {
-                if (pointer.gameObject.activeInHierarchy)
+                if (pointer.gameObject.activeInHierarchy && pointer.enabled)
                 {
                     List<RaycastResult> results = new List<RaycastResult>();
                     if (pointer.controller.pointerPressed)

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_BezierPointer.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_BezierPointer.cs
@@ -175,9 +175,18 @@ namespace VRTK
         {
             state = (pointerVisibility == pointerVisibilityStates.Always_On ? true : state);
 
-            projectedBeamForward.gameObject.SetActive(state);
-            projectedBeamJoint.gameObject.SetActive(state);
-            projectedBeamDown.SetActive(state);
+            if(projectedBeamForward)
+            {
+                projectedBeamForward.gameObject.SetActive(state);
+            }
+            if (projectedBeamJoint)
+            {
+                projectedBeamJoint.gameObject.SetActive(state);
+            }
+            if (projectedBeamDown)
+            {
+                projectedBeamDown.SetActive(state);
+            }
         }
 
         protected override void DisablePointerBeam(object sender, ControllerInteractionEventArgs e)

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_ControllerActions.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_ControllerActions.cs
@@ -23,6 +23,11 @@
 
         public void ToggleControllerModel(bool state, GameObject grabbedChildObject)
         {
+            if (!enabled)
+            {
+                return;
+            }
+
             foreach (MeshRenderer renderer in GetComponentsInChildren<MeshRenderer>())
             {
                 if (renderer.gameObject != grabbedChildObject && (grabbedChildObject == null || !renderer.transform.IsChildOf(grabbedChildObject.transform)))
@@ -43,6 +48,11 @@
 
         public void SetControllerOpacity(float alpha)
         {
+            if (!enabled)
+            {
+                return;
+            }
+
             alpha = Mathf.Clamp(alpha, 0f, 1f);
             foreach (var renderer in gameObject.GetComponentsInChildren<Renderer>())
             {
@@ -73,6 +83,11 @@
 
         public void HighlightControllerElement(GameObject element, Color? highlight, float fadeDuration = 0f)
         {
+            if (!enabled)
+            {
+                return;
+            }
+
             var renderer = element.GetComponent<Renderer>();
             if (renderer && renderer.material)
             {
@@ -87,6 +102,11 @@
 
         public void UnhighlightControllerElement(GameObject element)
         {
+            if (!enabled)
+            {
+                return;
+            }
+
             var renderer = element.GetComponent<Renderer>();
             if (renderer && renderer.material)
             {
@@ -146,12 +166,22 @@
 
         public void TriggerHapticPulse(ushort strength)
         {
+            if (!enabled)
+            {
+                return;
+            }
+
             hapticPulseStrength = (strength <= maxHapticVibration ? strength : maxHapticVibration);
             device.TriggerHapticPulse(hapticPulseStrength);
         }
 
         public void TriggerHapticPulse(ushort strength, float duration, float pulseInterval)
         {
+            if (!enabled)
+            {
+                return;
+            }
+
             hapticPulseStrength = (strength <= maxHapticVibration ? strength : maxHapticVibration);
             StartCoroutine(HapticPulse(duration, hapticPulseStrength, pulseInterval));
         }

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_HeadsetCollisionFade.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_HeadsetCollisionFade.cs
@@ -69,7 +69,7 @@
 
         private void OnTriggerStay(Collider collider)
         {
-            if (!collider.GetComponent<VRTK_PlayerObject>() && ValidTarget(collider.transform))
+            if (enabled && !collider.GetComponent<VRTK_PlayerObject>() && ValidTarget(collider.transform))
             {
                 OnHeadsetCollisionDetect(SetHeadsetCollisionEvent(collider, transform));
                 SteamVR_Fade.Start(fadeColor, blinkTransitionSpeed);

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractGrab.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractGrab.cs
@@ -90,7 +90,7 @@ namespace VRTK
             controllerActions = GetComponent<VRTK_ControllerActions>();
         }
 
-        private void Start()
+        private void OnEnable()
         {
             if (GetComponent<VRTK_ControllerEvents>() == null)
             {
@@ -102,6 +102,13 @@ namespace VRTK
             GetComponent<VRTK_ControllerEvents>().AliasGrabOff += new ControllerInteractionEventHandler(DoReleaseObject);
 
             SetControllerAttachPoint();
+        }
+
+        private void OnDisable()
+        {
+            ForceRelease();
+            GetComponent<VRTK_ControllerEvents>().AliasGrabOn -= new ControllerInteractionEventHandler(DoGrabObject);
+            GetComponent<VRTK_ControllerEvents>().AliasGrabOff -= new ControllerInteractionEventHandler(DoReleaseObject);
         }
 
         private void SetControllerAttachPoint()

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractTouch.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractTouch.cs
@@ -120,6 +120,12 @@ namespace VRTK
         {
             trackedController = GetComponent<SteamVR_TrackedObject>();
             controllerActions = GetComponent<VRTK_ControllerActions>();
+            Utilities.SetPlayerObject(gameObject, VRTK_PlayerObject.ObjectTypes.Controller);
+        }
+
+        private void OnDisable()
+        {
+            ForceStopTouching();
         }
 
         private void Start()
@@ -130,7 +136,6 @@ namespace VRTK
                 return;
             }
 
-            Utilities.SetPlayerObject(gameObject, VRTK_PlayerObject.ObjectTypes.Controller);
             CreateTouchCollider(gameObject);
             CreateTouchRigidBody(gameObject);
             CreateControllerRigidBody();
@@ -161,6 +166,11 @@ namespace VRTK
 
         private void OnTriggerStay(Collider collider)
         {
+            if (!enabled)
+            {
+                return;
+            }
+
             if (touchedObject != null && touchedObject != lastTouchedObject && !touchedObject.GetComponent<VRTK_InteractableObject>().IsGrabbed())
             {
                 CancelInvoke("ResetTriggerRumble");
@@ -275,7 +285,7 @@ namespace VRTK
             if (triggerOnStaticObjects)
             {
                 Rigidbody rb = obj.GetComponent<Rigidbody>();
-                if (rb==null)
+                if (rb == null)
                 {
                     rb = obj.AddComponent<Rigidbody>();
                 }

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractUse.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractUse.cs
@@ -78,7 +78,7 @@ namespace VRTK
             controllerActions = GetComponent<VRTK_ControllerActions>();
         }
 
-        private void Start()
+        private void OnEnable()
         {
             if (GetComponent<VRTK_ControllerEvents>() == null)
             {
@@ -88,6 +88,13 @@ namespace VRTK
 
             GetComponent<VRTK_ControllerEvents>().AliasUseOn += new ControllerInteractionEventHandler(DoStartUseObject);
             GetComponent<VRTK_ControllerEvents>().AliasUseOff += new ControllerInteractionEventHandler(DoStopUseObject);
+        }
+
+        private void OnDisable()
+        {
+            ForceStopUsing();
+            GetComponent<VRTK_ControllerEvents>().AliasUseOn -= new ControllerInteractionEventHandler(DoStartUseObject);
+            GetComponent<VRTK_ControllerEvents>().AliasUseOff -= new ControllerInteractionEventHandler(DoStopUseObject);
         }
 
         private bool IsObjectUsable(GameObject obj)

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractableObject.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractableObject.cs
@@ -424,7 +424,6 @@ namespace VRTK
         protected virtual void Start()
         {
             originalObjectColours = StoreOriginalColors();
-            RegisterTeleporters();
         }
 
         protected virtual void Update()
@@ -456,17 +455,22 @@ namespace VRTK
             }
         }
 
-        protected virtual void OnDisable()
-        {
-            ForceStopInteracting();
-        }
-
         protected virtual void OnEnable()
         {
+            RegisterTeleporters();
             if (forcedDropped)
             {
                 LoadPreviousState();
             }
+        }
+
+        protected virtual void OnDisable()
+        {
+            foreach (var teleporter in FindObjectsOfType<VRTK_BasicTeleport>())
+            {
+                teleporter.Teleported -= new TeleportEventHandler(OnTeleported);
+            }
+            ForceStopInteracting();
         }
 
         protected virtual void OnJointBreak(float force)


### PR DESCRIPTION
The event listeners are now managed in `OnEnable` and they are removed
in `OnDisable` to ensure they are no longer registered when the object
is no longer active.