### PR TITLE
fix(Interaction): ensure on grab collision delay is considered for tracked objects

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractGrab.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractGrab.cs
@@ -297,6 +297,8 @@ namespace VRTK
                 if (grabbedObject)
                 {
                     var objectScript = grabbedObject.GetComponent<VRTK_InteractableObject>();
+                    //Pause collisions (if allowed on object) for a moment whilst sorting out position to prevent clipping issues
+                    objectScript.PauseCollisions();
                     objectScript.SetGrabbedSnapHandle(GetSnapHandle(objectScript));
                     return true;
                 }


### PR DESCRIPTION
OnGrabCollisionDelay was not being considered for tracked objects on
being grabbed. I have added a call to PauseCollisions for tracked
objects which resolves that issue.