### PR TITLE
fix(Teleport): ensure nav mesh check uses destination position - resolves #277

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Examples/033_CameraRig_TeleportingInNavMesh.unity
+++ b/Assets/SteamVR_Unity_Toolkit/Examples/033_CameraRig_TeleportingInNavMesh.unity
@@ -765,8 +765,11 @@ MonoBehaviour:
   distanceBlinkDelay: 0
   headsetPositionCompensation: 1
   ignoreTargetWithTagOrClass: 
-  limitToNavMesh: 1
+  navMeshLimitDistance: 0.1
   playSpaceFalling: 1
+  useGravity: 1
+  gravityFallHeight: 1
+  blinkYThreshold: 0.1
 --- !u!114 &1784254474
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -780,12 +783,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   enableTeleport: 1
   controller: {fileID: 0}
+  pointerMaterial: {fileID: 0}
   pointerHitColor: {r: 0, g: 0.5, b: 0, a: 1}
   pointerMissColor: {r: 0.8, g: 0, b: 0, a: 1}
   showPlayAreaCursor: 0
   playAreaCursorDimensions: {x: 0, y: 0}
   handlePlayAreaCursorCollisions: 0
+  ignoreTargetWithTagOrClass: 
   pointerVisibility: 0
+  holdButtonToActivate: 1
   activateDelay: 0
   pointerLength: 10
   pointerDensity: 10
@@ -797,6 +803,8 @@ MonoBehaviour:
   layersToIgnore:
     serializedVersion: 2
     m_Bits: 4
+  validTeleportLocationObject: {fileID: 0}
+  rescalePointerTracer: 0
 --- !u!114 &1784254475
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -809,8 +817,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   pointerToggleButton: 3
+  pointerSetButton: 3
   grabToggleButton: 1
   useToggleButton: 0
+  uiClickButton: 0
   menuToggleButton: 4
   axisFidelity: 1
   triggerPressed: 0
@@ -823,6 +833,7 @@ MonoBehaviour:
   pointerPressed: 0
   grabPressed: 0
   usePressed: 0
+  uiClickPressed: 0
   menuPressed: 0
 --- !u!114 &1784254476
 MonoBehaviour:
@@ -837,16 +848,20 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   enableTeleport: 1
   controller: {fileID: 0}
+  pointerMaterial: {fileID: 0}
   pointerHitColor: {r: 0, g: 0.5, b: 0, a: 1}
   pointerMissColor: {r: 0.8, g: 0, b: 0, a: 1}
   showPlayAreaCursor: 0
   playAreaCursorDimensions: {x: 0, y: 0}
   handlePlayAreaCursorCollisions: 0
+  ignoreTargetWithTagOrClass: 
   pointerVisibility: 0
+  holdButtonToActivate: 1
   activateDelay: 0
   pointerThickness: 0.002
   pointerLength: 100
   showPointerTip: 1
+  customPointerCursor: {fileID: 0}
   layersToIgnore:
     serializedVersion: 2
     m_Bits: 4
@@ -862,8 +877,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   pointerToggleButton: 3
+  pointerSetButton: 3
   grabToggleButton: 1
   useToggleButton: 0
+  uiClickButton: 0
   menuToggleButton: 4
   axisFidelity: 1
   triggerPressed: 0
@@ -876,6 +893,7 @@ MonoBehaviour:
   pointerPressed: 0
   grabPressed: 0
   usePressed: 0
+  uiClickPressed: 0
   menuPressed: 0
 --- !u!1 &2040652510
 GameObject:

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_DestinationMarker.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_DestinationMarker.cs
@@ -42,7 +42,7 @@ namespace VRTK
         public event DestinationMarkerEventHandler DestinationMarkerSet;
 
         protected string invalidTargetWithTagOrClass;
-        protected bool checkNavMesh;
+        protected float navMeshCheckDistance;
         protected bool headsetPositionCompensation;
 
         public virtual void OnDestinationMarkerEnter(DestinationMarkerEventArgs e)
@@ -74,9 +74,9 @@ namespace VRTK
             invalidTargetWithTagOrClass = name;
         }
 
-        public virtual void SetNavMeshCheck(bool state)
+        public virtual void SetNavMeshCheckDistance(float distance)
         {
-            checkNavMesh = state;
+            navMeshCheckDistance = distance;
         }
 
         public virtual void SetHeadsetPositionCompensation(bool state)

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/Abstractions/VRTK_WorldPointer.cs
@@ -243,7 +243,7 @@ namespace VRTK
         protected virtual void TogglePointer(bool state)
         {
             var playAreaState = (showPlayAreaCursor ? state : false);
-            if(playAreaCursor)
+            if (playAreaCursor)
             {
                 playAreaCursor.gameObject.SetActive(playAreaState);
             }
@@ -263,7 +263,7 @@ namespace VRTK
 
         protected void UpdatePointerMaterial(Color color)
         {
-            if (playAreaCursorCollided || !ValidDestination(pointerContactTarget))
+            if (playAreaCursorCollided || !ValidDestination(pointerContactTarget, destinationPosition))
             {
                 color = pointerMissColor;
             }
@@ -271,15 +271,15 @@ namespace VRTK
             SetPointerMaterial();
         }
 
-        protected virtual bool ValidDestination(Transform target)
+        protected virtual bool ValidDestination(Transform target, Vector3 destinationPosition)
         {
             bool validNavMeshLocation = false;
             if (target)
             {
                 NavMeshHit hit;
-                validNavMeshLocation = NavMesh.SamplePosition(target.position, out hit, 1.0f, NavMesh.AllAreas);
+                validNavMeshLocation = NavMesh.SamplePosition(destinationPosition, out hit, 0.1f, NavMesh.AllAreas);
             }
-            if (!checkNavMesh)
+            if (navMeshCheckDistance == 0f)
             {
                 validNavMeshLocation = true;
             }

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_BezierPointer.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_BezierPointer.cs
@@ -316,7 +316,7 @@ namespace VRTK
                 UpdatePointerMaterial(pointerHitColor);
                 if (validTeleportLocationInstance != null)
                 {
-                    validTeleportLocationInstance.SetActive(ValidDestination(pointerContactTarget));
+                    validTeleportLocationInstance.SetActive(ValidDestination(pointerContactTarget, destinationPosition));
                 }
             }
             else

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_HeightAdjustTeleport.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_HeightAdjustTeleport.cs
@@ -137,7 +137,7 @@ namespace VRTK
                 bool rayHit = Physics.Raycast(ray, out rayCollidedWith);
                 float floorY = eyeCamera.transform.position.y - rayCollidedWith.distance;
 
-                if (rayHit && ValidLocation(rayCollidedWith.transform) && !FloorIsGrabbedObject(rayCollidedWith))
+                if (rayHit && ValidLocation(rayCollidedWith.transform, rayCollidedWith.point) && !FloorIsGrabbedObject(rayCollidedWith))
                 {
                     var floorDelta = currentRayDownY - floorY;
                     currentFloor = rayCollidedWith.transform.gameObject;

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -783,7 +783,7 @@ The Basic Teleport script is attached to the `[CameraRig]` prefab and requires a
   * **Distance Blink Delay:** A range between 0 and 32 that determines how long the blink transition will stay blacked out depending on the distance being teleported. A value of 0 will not delay the teleport blink effect over any distance, a value of 32 will delay the teleport blink fade in even when the distance teleported is very close to the original position. This can be used to simulate time taking longer to pass the further a user teleports. A value of 16 provides a decent basis to simulate this to the user.
   * **Headset Position Compensation:** If this is checked then the teleported location will be the position of the headset within the play area. If it is unchecked then the teleported location will always be the centre of the play area even if the headset position is not in the centre of the play area.
   * **Ignore Target With Tag Or Class:** A string that specifies an object Tag or the name of a Script attached to an obejct and notifies the teleporter that the destination is to be ignored so the user cannot teleport to that location. It also ensure the pointer colour is set to the miss colour.
-  * **Limit To Nav Mesh:** If this is checked then teleporting will be limited to the bounds of a baked NavMesh. If the pointer destination is outside the NavMesh then it will be ignored.
+  * **Nav Mesh Limit Distance:** The max distance the nav mesh edge can be from the teleport destination to be considered valid. If a value of `0` is given then the nav mesh restriction will be ignored..
 
 ### Class Events
 
@@ -828,7 +828,7 @@ Like the basic teleporter the Height Adjust Teleport script is attached to the `
   * **Distance Blink Delay:** A range between 0 and 32 that determines how long the blink transition will stay blacked out depending on the distance being teleported. A value of 0 will not delay the teleport blink effect over any distance, a value of 32 will delay the teleport blink fade in even when the distance teleported is very close to the original position. This can be used to simulate time taking longer to pass the further a user teleports. A value of 16 provides a decent basis to simulate this to the user.
   * **Headset Position Compensation:** If this is checked then the teleported location will be the position of the headset within the play area. If it is unchecked then the teleported location will always be the centre of the play area even if the headset position is not in the centre of the play area.
   * **Ignore Target With Tag Or Class:** A string that specifies an object Tag or the name of a Script attached to an obejct and notifies the teleporter that the destination is to be ignored so the user cannot teleport to that location. It also ensure the pointer colour is set to the miss colour.
-  * **Limit To Nav Mesh:** If this is checked then teleporting will be limited to the bounds of a baked NavMesh. If the pointer destination is outside the NavMesh then it will be ignored.
+  * **Nav Mesh Limit Distance:** The max distance the nav mesh edge can be from the teleport destination to be considered valid. If a value of `0` is given then the nav mesh restriction will be ignored..
   * **Play Space Falling:** Checks if the user steps off an object into a part of their play area that is not on the object then they are automatically teleported down to the nearest floor. The `Play Space Falling` option also works in the opposite way that if the user's headset is above an object then the user is teleported automatically on top of that object, which is useful for simulating climbing stairs without needing to use the pointer beam location. If this option is turned off then the user can hover in mid air at the same y position of the object they are standing on.
   * **Use Gravity**: allows for gravity based falling when the distance is greater than `Gravity Fall Height`.
   * **Gravity Fall Height**: Fall distance needed before gravity based falling can be triggered.
@@ -1931,16 +1931,16 @@ It is utilised by the `VRTK_WorldPointer` for dealing with pointer events when t
 
 The SetInvalidTarget method is used to set objects that contain the given tag or class matching the name as invalid destination targets.
 
-#### SetNavMeshCheck/1
+#### SetNavMeshCheckDistance/1
 
-  > `public virtual void SetNavMeshCheck(bool state)`
+  > `public virtual void SetNavMeshCheckDistance(float distance)`
 
   * Parameters
-   * `bool state` - The state of whether a nav mesh should be checked for valid destination targets.
+   * `float distance` - The max distance the nav mesh can be from the sample point to be valid..
   * Returns
    * _none_
 
-The SetNavMeshCheck method sets the destination marker to include or ignore nav meshes when setting a destination marker. If `true` then the destination marker can only be set if the destination position is a point within a valid nav mesh.
+The SetNavMeshCheckDistance method sets the max distance the destination marker position can be from the edge of a nav mesh to be considered a valid destination.
 
 #### SetHeadsetPositionCompensation/1
 


### PR DESCRIPTION
Previously, the nav mesh check would use the origin position of the
target to see if it was within the nav mesh boundaries. This would
cause false positives to be reported. The solution is to check the
actual destination position vector.