### PR TITLE
feat(Controller): optionally disable the pointer on grab or on use

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1098,6 +1098,10 @@ The basis of this script is to provide a simple mechanism for identifying object
    * `Default` means using controller settings.
    * `Override Hide` means hiding the controller when using, overriding controller settings.
    * `Override Dont Hide` means *not* hiding the controller when using, overriding controller settings.
+  * **Pointer Disable Mode:** Optionally disable the controller pointer on grab or on use:
+   * `Dont Disable` means not disabling the pointer.
+   * `On Grab` means disabling the pointer when grabbed.
+   * `On Use` means disabling the pointer when using.
 
 ### Class Events
 


### PR DESCRIPTION
Add to Interactable Object a **Pointer Disable Mode** option
(`pointerDisableMode` in `VRTK_InteractableObject`) of type
`PointerDisableMode`:
 * `DontDisable` means not disabling the pointer.
 * `OnGrab` means disabling the pointer when grabbed.
 * `OnUse` means disabling the pointer when using.

Update methods `StartUsing` `StopUsing` `Grabbed` `Ungrabbed` to
support this option.