### PR TITLE
chore(HeadsetCollisionFade): Independent blink times and base class

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_BasicTeleport.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_BasicTeleport.cs
@@ -198,7 +198,7 @@ namespace VRTK
 
         private void InitHeadsetCollisionListener(bool state)
         {
-            var headset = FindObjectOfType<VRTK_HeadsetCollisionFade>();
+            var headset = FindObjectOfType<VRTK_HeadsetCollisionFadeBase>();
             if (headset)
             {
                 if (state)

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_HeadsetCollisionFade.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_HeadsetCollisionFade.cs
@@ -10,40 +10,16 @@
 
     public delegate void HeadsetCollisionEventHandler(object sender, HeadsetCollisionEventArgs e);
 
-    public class VRTK_HeadsetCollisionFade : MonoBehaviour
+    public abstract class VRTK_HeadsetCollisionFadeBase : MonoBehaviour
     {
-        public float blinkTransitionSpeed = 0.1f;
+        public float blinkTransitionSpeedEnter = 0.1f;
+        public float blinkTransitionSpeedExit = 0.1f;
         public Color fadeColor = Color.black;
-        public string ignoreTargetWithTagOrClass;
 
         public event HeadsetCollisionEventHandler HeadsetCollisionDetect;
         public event HeadsetCollisionEventHandler HeadsetCollisionEnded;
 
-        public virtual void OnHeadsetCollisionDetect(HeadsetCollisionEventArgs e)
-        {
-            if (HeadsetCollisionDetect != null)
-            {
-                HeadsetCollisionDetect(this, e);
-            }
-        }
-
-        public virtual void OnHeadsetCollisionEnded(HeadsetCollisionEventArgs e)
-        {
-            if (HeadsetCollisionEnded != null)
-            {
-                HeadsetCollisionEnded(this, e);
-            }
-        }
-
-        private HeadsetCollisionEventArgs SetHeadsetCollisionEvent(Collider collider, Transform currentTransform)
-        {
-            HeadsetCollisionEventArgs e;
-            e.collider = collider;
-            e.currentTransform = currentTransform;
-            return e;
-        }
-
-        private void Start()
+        protected virtual void Start()
         {
             Utilities.AddCameraFade();
             if (gameObject.GetComponentInChildren<SteamVR_Fade>() == null)
@@ -52,6 +28,42 @@
             }
 
             Utilities.SetPlayerObject(gameObject, VRTK_PlayerObject.ObjectTypes.Headset);
+        }
+
+        public virtual void OnHeadsetCollisionDetect(HeadsetCollisionEventArgs e)
+        {
+            if (HeadsetCollisionDetect != null)
+            {
+                HeadsetCollisionDetect(this, e);
+            }
+            SteamVR_Fade.Start(fadeColor, blinkTransitionSpeedEnter);
+        }
+
+        public virtual void OnHeadsetCollisionEnded(HeadsetCollisionEventArgs e)
+        {
+            if (HeadsetCollisionEnded != null)
+            {
+                HeadsetCollisionEnded(this, e);
+            }
+            SteamVR_Fade.Start(Color.clear, blinkTransitionSpeedExit);
+        }
+
+        protected HeadsetCollisionEventArgs SetHeadsetCollisionEvent(Collider collider, Transform currentTransform)
+        {
+            HeadsetCollisionEventArgs e;
+            e.collider = collider;
+            e.currentTransform = currentTransform;
+            return e;
+        }
+    }
+
+    public class VRTK_HeadsetCollisionFade : VRTK_HeadsetCollisionFadeBase
+    {
+        public string ignoreTargetWithTagOrClass;
+
+        protected override void Start()
+        {
+            base.Start();
 
             BoxCollider collider = gameObject.AddComponent<BoxCollider>();
             collider.isTrigger = true;
@@ -62,27 +74,21 @@
             rb.useGravity = false;
         }
 
-        private bool ValidTarget(Transform target)
+        protected virtual bool ValidTarget(Transform target)
         {
             return (target && target.tag != ignoreTargetWithTagOrClass && target.GetComponent(ignoreTargetWithTagOrClass) == null);
         }
 
-        private void OnTriggerStay(Collider collider)
+        protected virtual void OnTriggerStay(Collider collider)
         {
             if (enabled && !collider.GetComponent<VRTK_PlayerObject>() && ValidTarget(collider.transform))
-            {
                 OnHeadsetCollisionDetect(SetHeadsetCollisionEvent(collider, transform));
-                SteamVR_Fade.Start(fadeColor, blinkTransitionSpeed);
-            }
         }
 
-        private void OnTriggerExit(Collider collider)
+        protected virtual void OnTriggerExit(Collider collider)
         {
             if (!collider.GetComponent<VRTK_PlayerObject>())
-            {
                 OnHeadsetCollisionEnded(SetHeadsetCollisionEvent(collider, transform));
-                SteamVR_Fade.Start(Color.clear, blinkTransitionSpeed);
-            }
         }
     }
 }

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_PlayerClimb.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_PlayerClimb.cs
@@ -31,7 +31,7 @@
 
         private VRTK_PlayerPresence playerPresence;
         private bool lastGravitySetting;
-        private VRTK_HeadsetCollisionFade collisionFade;
+        private VRTK_HeadsetCollisionFadeBase collisionFade;
         private SteamVR_ControllerManager controllerManager;
 
         private GameObject climbingObject;

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_PlayerPresence.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_PlayerPresence.cs
@@ -141,15 +141,15 @@
 
         private void InitHeadsetListeners(bool state)
         {
-            if (headset.GetComponent<VRTK_HeadsetCollisionFade>())
+            if (headset.GetComponent<VRTK_HeadsetCollisionFadeBase>())
             {
                 if (state)
                 {
-                    headset.GetComponent<VRTK_HeadsetCollisionFade>().HeadsetCollisionDetect += new HeadsetCollisionEventHandler(OnHeadsetCollision);
+                    headset.GetComponent<VRTK_HeadsetCollisionFadeBase>().HeadsetCollisionDetect += new HeadsetCollisionEventHandler(OnHeadsetCollision);
                 }
                 else
                 {
-                    headset.GetComponent<VRTK_HeadsetCollisionFade>().HeadsetCollisionDetect -= new HeadsetCollisionEventHandler(OnHeadsetCollision);
+                    headset.GetComponent<VRTK_HeadsetCollisionFadeBase>().HeadsetCollisionDetect -= new HeadsetCollisionEventHandler(OnHeadsetCollision);
                 }
             }
         }

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -903,9 +903,14 @@ If the headset is colliding then the teleport action is also disabled to prevent
   > * If using `Unity 5.3` or older then the Headset Collision Fade script is attached to the `Camera (head)` object within the `[CameraRig]` prefab.
   > * If using `Unity 5.4` or newer then the Headset Collision Fade script is attached to the `Camera (eye)` object within the `[CameraRig]->Camera (head)` prefab.
 
+### Extending
+
+A base class (VRTK_HeadsetCollisionFadeBase) is provided that takes care of the actual fading and event dispatching. Different methods may be implemented to define when the collision starts and ends, just call OnHeadsetCollisionDetect and OnHeadsetCollisionEnded when applicable. Classes that want to listen to the events should look for the base class instead of the specific implementation used so they are interchangeable.
+  
 ### Inspector Parameters
 
-  * **Blink Transition Speed:** The fade blink speed on collision.
+  * **Blink Transition Speed Enter:** The fade blink speed on collision enter.
+  * **Blink Transition Speed Enter:** The fade blink speed on collision exit.
   * **Fade Color:** The colour to fade the headset to on collision.
   * **Ignore Target With Tag Or Class:** A string that specifies an object Tag or the name of a Script attached to an obejct and will prevent the object from fading the headset view on collision.
 


### PR DESCRIPTION
Simple changes to make HeadsetCollisionFade extendable/modifiable. Also took the chance to add another variable to get independent fade times.

Yesterday I implemented (not in this commit) a different version of the HeadsetCollisionFade script that created a gameobject with a collider just in the last good position and checked that you were inside this collider and outside others before fading back. Also, if you kept moving further it resetted the position of the CameraRig so just backing a little bit always faded you back to a good position. This way the player can't go through walls and cheat.

If this commit is good for you I will implement cleanly this different method in a new script that inherits from the new base so users can choose or create other methods.