### PR TITLE
fix(Controller): enhance AutoGrab script

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_ObjectAutoGrab.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_ObjectAutoGrab.cs
@@ -5,7 +5,7 @@
 
     public class VRTK_ObjectAutoGrab : MonoBehaviour
     {
-        public GameObject objectToGrab;
+        public VRTK_InteractableObject objectToGrab;
         public bool cloneGrabbedObject;
 
         private VRTK_InteractGrab controller;
@@ -13,15 +13,16 @@
         private IEnumerator Start()
         {
             controller = GetComponent<VRTK_InteractGrab>();
-
             if (!controller)
             {
                 Debug.LogError("The VRTK_InteractGrab script is required to be attached to the controller along with this script.");
+                yield break;
             }
 
-            if (!objectToGrab || !objectToGrab.GetComponent<VRTK_InteractableObject>())
+            if (!objectToGrab)
             {
-                Debug.LogError("The objectToGrab Game Object must have the VRTK_InteractableObject script applied to it.");
+                Debug.LogError("You have to assign an object that should be grabbed.");
+                yield break;
             }
 
             while (controller.controllerAttachPoint == null)
@@ -29,12 +30,13 @@
                 yield return true;
             }
 
-            var grabbableObject = objectToGrab;
+            VRTK_InteractableObject grabbableObject = objectToGrab;
             if (cloneGrabbedObject)
             {
                 grabbableObject = Instantiate(objectToGrab);
             }
-            controller.GetComponent<VRTK_InteractTouch>().ForceTouch(grabbableObject);
+            controller.GetComponent<VRTK_InteractTouch>().ForceStopTouching();
+            controller.GetComponent<VRTK_InteractTouch>().ForceTouch(grabbableObject.gameObject);
             controller.AttemptGrab();
         }
     }


### PR DESCRIPTION
AutoGrab would fail if the controllers initially already touched
something. This is now fixed.

Also stronger typing has been introduced and the script flow fixed so
that now error messages also appear in the console.