### PR TITLE
fix(Controller): ensure rigidbody on not touching works on auto drop - resolves #405

### DIFF
--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractGrab.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractGrab.cs
@@ -35,6 +35,7 @@ namespace VRTK
         private SteamVR_TrackedObject trackedController;
         private VRTK_InteractTouch interactTouch;
         private VRTK_ControllerActions controllerActions;
+        private VRTK_ControllerEvents controllerEvents;
 
         private int grabEnabledState = 0;
         private float grabPrecognitionTimer = 0f;
@@ -88,6 +89,7 @@ namespace VRTK
             interactTouch = GetComponent<VRTK_InteractTouch>();
             trackedController = GetComponent<SteamVR_TrackedObject>();
             controllerActions = GetComponent<VRTK_ControllerActions>();
+            controllerEvents = GetComponent<VRTK_ControllerEvents>();
         }
 
         private void OnEnable()
@@ -349,7 +351,7 @@ namespace VRTK
                 {
                     grabbedObjectScript.ToggleKinematic(true);
                 }
-                updatedHideControllerOnGrab = grabbedObjectScript.CheckHideMode(hideControllerOnGrab, grabbedObjectScript.hideControllerOnGrab );
+                updatedHideControllerOnGrab = grabbedObjectScript.CheckHideMode(hideControllerOnGrab, grabbedObjectScript.hideControllerOnGrab);
             }
 
             if (updatedHideControllerOnGrab)
@@ -469,10 +471,6 @@ namespace VRTK
             else
             {
                 grabPrecognitionTimer = Time.time + grabPrecognition;
-                if (createRigidBodyWhenNotTouching)
-                {
-                    interactTouch.ToggleControllerRigidBody(true);
-                }
             }
         }
 
@@ -498,7 +496,6 @@ namespace VRTK
                     ReleaseObject(controllerIndex, true);
                 }
             }
-            interactTouch.ToggleControllerRigidBody(false);
         }
 
         private void DoGrabObject(object sender, ControllerInteractionEventArgs e)
@@ -516,6 +513,14 @@ namespace VRTK
             if (controllerAttachPoint == null)
             {
                 SetControllerAttachPoint();
+            }
+
+            if (createRigidBodyWhenNotTouching && grabbedObject == null)
+            {
+                if (interactTouch.IsRigidBodyActive() != controllerEvents.grabPressed)
+                {
+                    interactTouch.ToggleControllerRigidBody(controllerEvents.grabPressed);
+                }
             }
 
             if (grabPrecognitionTimer >= Time.time)

--- a/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractTouch.cs
+++ b/Assets/SteamVR_Unity_Toolkit/Scripts/VRTK_InteractTouch.cs
@@ -119,6 +119,11 @@ namespace VRTK
             }
         }
 
+        public bool IsRigidBodyActive()
+        {
+            return !touchRigidBody.isKinematic;
+        }
+
         public void ForceStopTouching()
         {
             if (touchedObject != null)

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1464,7 +1464,7 @@ The ForceTouch method will attempt to force the controller to touch the given ga
 
 The GetTouchedObject method returns the current object being touched by the controller.
 
-#### IsObjectInteractable
+#### IsObjectInteractable/1
 
   > `public bool IsObjectInteractable(GameObject obj)`
 
@@ -1485,6 +1485,17 @@ The IsObjectInteractable method is used to check if a given game object is of ty
    * _none_
 
 The ToggleControllerRigidBody method toggles the controller's rigidbody's ability to detect collisions. If it is true then the controller rigidbody will collide with other collidable game objects.
+
+#### IsRigidBodyActive/0
+
+  > `public bool IsRigidBodyActive()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * `bool` - Is true if the rigidbody on the controller is currently active and able to affect other scene rigidbodies.
+
+The IsRigidBodyActive method toggle
 
 #### ForceStopTouching/0
 


### PR DESCRIPTION
The `Create Rigid Body When Not Touching` flag on the Interact Grab
script would only create a rigidbody on the grab event, so when an
item was being held but then dropped automatically (e.g. by banging it
into a wall and breaking the joint) but the grab button was still being
held down, the rigidbody would not activate.

This fix moves the logic into the Update routine so it constantly
checks for the state of the grab button and toggles the rigidbody
accordingly.