### PR TITLE
feat(Controller): add trigger click threshold parameter

### DIFF
--- a/Assets/VRTK/Examples/002_Controller_Events.unity
+++ b/Assets/VRTK/Examples/002_Controller_Events.unity
@@ -357,6 +357,7 @@ MonoBehaviour:
   uiClickButton: 3
   menuToggleButton: 7
   axisFidelity: 1
+  triggerClickThreshold: 1
   triggerPressed: 0
   triggerTouched: 0
   triggerHairlinePressed: 0
@@ -401,6 +402,7 @@ MonoBehaviour:
   uiClickButton: 3
   menuToggleButton: 7
   axisFidelity: 1
+  triggerClickThreshold: 1
   triggerPressed: 0
   triggerTouched: 0
   triggerHairlinePressed: 0

--- a/Assets/VRTK/Scripts/VRTK_ControllerEvents.cs
+++ b/Assets/VRTK/Scripts/VRTK_ControllerEvents.cs
@@ -35,6 +35,7 @@
         public ButtonAlias menuToggleButton = ButtonAlias.Application_Menu;
 
         public int axisFidelity = 1;
+        public float triggerClickThreshold = 1f;
 
         [HideInInspector]
         public bool triggerPressed = false;
@@ -629,12 +630,12 @@
             }
 
             //Trigger Clicked
-            if (!triggerClicked && currentTriggerAxis.x == 1f)
+            if (!triggerClicked && currentTriggerAxis.x >= triggerClickThreshold)
             {
                 OnTriggerClicked(SetButtonEvent(ref triggerClicked, true, currentTriggerAxis.x));
                 EmitAlias(ButtonAlias.Trigger_Click, true, currentTriggerAxis.x, ref triggerClicked);
             }
-            else if (triggerClicked && currentTriggerAxis.x < 1f)
+            else if (triggerClicked && currentTriggerAxis.x < triggerClickThreshold)
             {
                 OnTriggerUnclicked(SetButtonEvent(ref triggerClicked, false, 0f));
                 EmitAlias(ButtonAlias.Trigger_Click, false, 0f, ref triggerClicked);

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -231,6 +231,7 @@ The script also has a public boolean pressed state for the buttons to allow the 
   * **UI Click Button:** The button to use for the action of clicking a UI element.
   * **Menu Toggle Button:** The button to use for the action of bringing up an in-game menu.
   * **Axis Fidelity:** The amount of fidelity in the changes on the axis, which is defaulted to 1. Any number higher than 2 will probably give too sensitive results.
+  * **Trigger Click Threshold:** The level on the trigger axis to reach before a click is registered.
 
 ### Class Variables
 


### PR DESCRIPTION
It's now possible to specify the click threshold that the trigger axis
must exceed for a click to be registered.

The reason for this is, the trigger click should happen when the axis
has reached it's maximum level of 1f but this is achieved by a
microswitch inside the controller trigger being pressed and when it is
pressed it changes the trigger axis to 1f. However, if the controller
microswitch is broken and not registering the click then the trigger
axis is never set to 1f and therefore the trigger click event is never
emitted. This setting gives the ability to reduce the threshold to a
level where a click even can still be recognised on faulty hardware.