### PR TITLE
fix(Interaction): make tracked objects throw the same as other objects

### DIFF
--- a/Assets/VRTK/Scripts/VRTK_InteractGrab.cs
+++ b/Assets/VRTK/Scripts/VRTK_InteractGrab.cs
@@ -57,7 +57,7 @@ namespace VRTK
 
         public void ForceRelease()
         {
-            if (grabbedObject != null && grabbedObject.GetComponent<VRTK_InteractableObject>() && grabbedObject.GetComponent<VRTK_InteractableObject>().AttachIsTrackObject())
+            if (grabbedObject != null && grabbedObject.GetComponent<VRTK_InteractableObject>() && grabbedObject.GetComponent<VRTK_InteractableObject>().AttachIsUnthrowableObject())
             {
                 UngrabTrackedObject();
             }
@@ -484,7 +484,7 @@ namespace VRTK
         {
             if (CanRelease() && (IsObjectHoldOnGrab(grabbedObject) || grabEnabledState >= 2))
             {
-                if (grabbedObject.GetComponent<VRTK_InteractableObject>().AttachIsTrackObject())
+                if (grabbedObject.GetComponent<VRTK_InteractableObject>().AttachIsUnthrowableObject())
                 {
                     UngrabTrackedObject();
                 }

--- a/Assets/VRTK/Scripts/VRTK_InteractableObject.cs
+++ b/Assets/VRTK/Scripts/VRTK_InteractableObject.cs
@@ -322,6 +322,11 @@ namespace VRTK
             return AttachIsClimbObject(); // only one at the moment
         }
 
+        public bool AttachIsUnthrowableObject()
+        {
+            return (grabAttachMechanic == GrabAttachType.Rotator_Track);
+        }
+
         public void ZeroVelocity()
         {
             if (GetComponent<Rigidbody>())

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1357,6 +1357,17 @@ The AttachIsKinematicObject method is used to determine if the object has kinema
 
 The AttachIsStaticObject method is used to determine if the object is using one of the static grab attach types.
 
+#### AttachIsUnthrowableObject/0
+
+  > `public bool AttachIsUnthrowableObject()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * `bool` - Is true if the grab attach mechanic is of a type that shouldn't be considered thrown when released.
+
+The AttachIsUnthrowableObject method is used to determine if the object is using one of the grab types that should not be thrown when released.
+
 #### ZeroVelocity/0
 
   > `public void ZeroVelocity()`


### PR DESCRIPTION
Tracked objects were not being thrown in the same way as other object
grab types like joints or child of controller meaning that they would
be thrown with a lot more force which made them feel unnatural. This
has been resolved to ensure they feel the same as other objects when
thrown.