### PR TITLE
feat(Headset): decouple collision and fade into separate scripts - resolves #436

### DIFF
--- a/Assets/VRTK/Scripts/VRTK_BasicTeleport.cs
+++ b/Assets/VRTK/Scripts/VRTK_BasicTeleport.cs
@@ -195,7 +195,7 @@ namespace VRTK
 
         private void InitHeadsetCollisionListener(bool state)
         {
-            var headset = FindObjectOfType<VRTK_HeadsetCollisionFade>();
+            var headset = FindObjectOfType<VRTK_HeadsetCollision>();
             if (headset)
             {
                 if (state)

--- a/Assets/VRTK/Scripts/VRTK_HeadsetCollision.cs
+++ b/Assets/VRTK/Scripts/VRTK_HeadsetCollision.cs
@@ -1,0 +1,95 @@
+﻿namespace VRTK
+{
+    using UnityEngine;
+
+    public struct HeadsetCollisionEventArgs
+    {
+        public Collider collider;
+        public Transform currentTransform;
+    }
+
+    public delegate void HeadsetCollisionEventHandler(object sender, HeadsetCollisionEventArgs e);
+
+    public class VRTK_HeadsetCollision : MonoBehaviour
+    {
+        public string ignoreTargetWithTagOrClass;
+
+        public event HeadsetCollisionEventHandler HeadsetCollisionDetect;
+        public event HeadsetCollisionEventHandler HeadsetCollisionEnded;
+
+        private bool headsetColliding = false;
+
+        public virtual void OnHeadsetCollisionDetect(HeadsetCollisionEventArgs e)
+        {
+            if (HeadsetCollisionDetect != null)
+            {
+                HeadsetCollisionDetect(this, e);
+            }
+        }
+
+        public virtual void OnHeadsetCollisionEnded(HeadsetCollisionEventArgs e)
+        {
+            if (HeadsetCollisionEnded != null)
+            {
+                HeadsetCollisionEnded(this, e);
+            }
+        }
+
+        public virtual bool IsColliding()
+        {
+            return headsetColliding;
+        }
+
+        private void OnEnable()
+        {
+            headsetColliding = false;
+            Utilities.SetPlayerObject(gameObject, VRTK_PlayerObject.ObjectTypes.Headset);
+
+            BoxCollider collider = gameObject.AddComponent<BoxCollider>();
+            collider.isTrigger = true;
+            collider.size = new Vector3(0.1f, 0.1f, 0.1f);
+
+            Rigidbody rb = gameObject.AddComponent<Rigidbody>();
+            rb.isKinematic = true;
+            rb.useGravity = false;
+        }
+
+        private void OnDisable()
+        {
+            headsetColliding = false;
+            Destroy(gameObject.GetComponent<BoxCollider>());
+            Destroy(gameObject.GetComponent<Rigidbody>());
+        }
+
+        private HeadsetCollisionEventArgs SetHeadsetCollisionEvent(Collider collider, Transform currentTransform)
+        {
+            HeadsetCollisionEventArgs e;
+            e.collider = collider;
+            e.currentTransform = currentTransform;
+            return e;
+        }
+
+        private bool ValidTarget(Transform target)
+        {
+            return (target && target.tag != ignoreTargetWithTagOrClass && target.GetComponent(ignoreTargetWithTagOrClass) == null);
+        }
+
+        private void OnTriggerStay(Collider collider)
+        {
+            if (enabled && !collider.GetComponent<VRTK_PlayerObject>() && ValidTarget(collider.transform))
+            {
+                headsetColliding = true;
+                OnHeadsetCollisionDetect(SetHeadsetCollisionEvent(collider, transform));
+            }
+        }
+
+        private void OnTriggerExit(Collider collider)
+        {
+            if (!collider.GetComponent<VRTK_PlayerObject>())
+            {
+                headsetColliding = false;
+                OnHeadsetCollisionEnded(SetHeadsetCollisionEvent(collider, transform));
+            }
+        }
+    }
+}

--- a/Assets/VRTK/Scripts/VRTK_HeadsetCollision.cs.meta
+++ b/Assets/VRTK/Scripts/VRTK_HeadsetCollision.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 057015237f68bd74d9c6c6c28ea347e9
+timeCreated: 1472137181
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/VRTK_HeadsetFade.cs
+++ b/Assets/VRTK/Scripts/VRTK_HeadsetFade.cs
@@ -1,0 +1,119 @@
+﻿namespace VRTK
+{
+    using UnityEngine;
+
+    public struct HeadsetFadeEventArgs
+    {
+        public float timeTillComplete;
+        public Transform currentTransform;
+    }
+
+    public delegate void HeadsetFadeEventHandler(object sender, HeadsetFadeEventArgs e);
+
+    public class VRTK_HeadsetFade : MonoBehaviour
+    {
+        public event HeadsetFadeEventHandler HeadsetFadeStart;
+        public event HeadsetFadeEventHandler HeadsetFadeComplete;
+        public event HeadsetFadeEventHandler HeadsetUnfadeStart;
+        public event HeadsetFadeEventHandler HeadsetUnfadeComplete;
+
+        private bool isTransitioning = false;
+        private bool isFaded = false;
+
+        public virtual void OnHeadsetFadeStart(HeadsetFadeEventArgs e)
+        {
+            if (HeadsetFadeStart != null)
+            {
+                HeadsetFadeStart(this, e);
+            }
+        }
+
+        public virtual void OnHeadsetFadeComplete(HeadsetFadeEventArgs e)
+        {
+            if (HeadsetFadeComplete != null)
+            {
+                HeadsetFadeComplete(this, e);
+            }
+        }
+
+        public virtual void OnHeadsetUnfadeStart(HeadsetFadeEventArgs e)
+        {
+            if (HeadsetUnfadeStart != null)
+            {
+                HeadsetUnfadeStart(this, e);
+            }
+        }
+
+        public virtual void OnHeadsetUnfadeComplete(HeadsetFadeEventArgs e)
+        {
+            if (HeadsetUnfadeComplete != null)
+            {
+                HeadsetUnfadeComplete(this, e);
+            }
+        }
+
+        public virtual bool IsFaded()
+        {
+            return isFaded;
+        }
+
+        public virtual bool IsTransitioning()
+        {
+            return isTransitioning;
+        }
+
+        public virtual void Fade(Color color, float duration)
+        {
+            isFaded = false;
+            isTransitioning = true;
+            VRTK_SDK_Bridge.HeadsetFade(color, duration);
+            OnHeadsetFadeStart(SetHeadsetFadeEvent(transform, duration));
+            CancelInvoke("UnfadeComplete");
+            Invoke("FadeComplete", duration);
+        }
+
+        public virtual void Unfade(float duration)
+        {
+            isFaded = true;
+            isTransitioning = true;
+            VRTK_SDK_Bridge.HeadsetFade(Color.clear, duration);
+            OnHeadsetUnfadeStart(SetHeadsetFadeEvent(transform, duration));
+            CancelInvoke("FadeComplete");
+            Invoke("UnfadeComplete", duration);
+        }
+
+        private void Start()
+        {
+            isTransitioning = false;
+            isFaded = false;
+
+            Utilities.AddCameraFade();
+            if (!VRTK_SDK_Bridge.HasHeadsetFade(gameObject))
+            {
+                Debug.LogWarning("This 'VRTK_HeadsetCollisionFade' script needs a compatible fade script on the camera eye.");
+            }
+        }
+
+        private HeadsetFadeEventArgs SetHeadsetFadeEvent(Transform currentTransform, float duration)
+        {
+            HeadsetFadeEventArgs e;
+            e.timeTillComplete = duration;
+            e.currentTransform = currentTransform;
+            return e;
+        }
+
+        private void FadeComplete()
+        {
+            isFaded = true;
+            isTransitioning = false;
+            OnHeadsetFadeComplete(SetHeadsetFadeEvent(transform, 0f));
+        }
+
+        private void UnfadeComplete()
+        {
+            isFaded = false;
+            isTransitioning = false;
+            OnHeadsetUnfadeComplete(SetHeadsetFadeEvent(transform, 0f));
+        }
+    }
+}

--- a/Assets/VRTK/Scripts/VRTK_HeadsetFade.cs.meta
+++ b/Assets/VRTK/Scripts/VRTK_HeadsetFade.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 44596d094d0946345a7fc6688ba9c06c
+timeCreated: 1472138057
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/VRTK_PlayerClimb.cs
+++ b/Assets/VRTK/Scripts/VRTK_PlayerClimb.cs
@@ -30,7 +30,8 @@
         private bool isClimbing = false;
 
         private VRTK_PlayerPresence playerPresence;
-        private VRTK_HeadsetCollisionFade collisionFade;
+        private VRTK_HeadsetCollision headsetCollision;
+        private VRTK_HeadsetFade headsetFade;
 
         private GameObject climbingObject;
 
@@ -73,10 +74,16 @@
             }
 
             headCamera = VRTK_DeviceFinder.HeadsetTransform();
-            collisionFade = headCamera.GetComponent<VRTK_HeadsetCollisionFade>();
-            if (collisionFade == null)
+            headsetCollision = headCamera.GetComponent<VRTK_HeadsetCollision>();
+            if (headsetCollision == null)
             {
-                collisionFade = headCamera.gameObject.AddComponent<VRTK_HeadsetCollisionFade>();
+                headsetCollision = headCamera.gameObject.AddComponent<VRTK_HeadsetCollision>();
+            }
+
+            headsetFade = headCamera.GetComponent<VRTK_HeadsetFade>();
+            if (headsetFade == null)
+            {
+                headsetFade = headCamera.gameObject.AddComponent<VRTK_HeadsetFade>();
             }
         }
 
@@ -121,13 +128,13 @@
         {
             if (state)
             {
-                collisionFade.HeadsetCollisionDetect += new HeadsetCollisionEventHandler(OnHeadsetCollisionDetected);
-                collisionFade.HeadsetCollisionEnded += new HeadsetCollisionEventHandler(OnHeadsetCollisionEnded);
+                headsetCollision.HeadsetCollisionDetect += new HeadsetCollisionEventHandler(OnHeadsetCollisionDetected);
+                headsetCollision.HeadsetCollisionEnded += new HeadsetCollisionEventHandler(OnHeadsetCollisionEnded);
             }
             else
             {
-                collisionFade.HeadsetCollisionDetect -= new HeadsetCollisionEventHandler(OnHeadsetCollisionDetected);
-                collisionFade.HeadsetCollisionEnded -= new HeadsetCollisionEventHandler(OnHeadsetCollisionEnded);
+                headsetCollision.HeadsetCollisionDetect -= new HeadsetCollisionEventHandler(OnHeadsetCollisionDetected);
+                headsetCollision.HeadsetCollisionEnded -= new HeadsetCollisionEventHandler(OnHeadsetCollisionEnded);
             }
         }
 
@@ -176,11 +183,13 @@
 
         private void OnHeadsetCollisionDetected(object sender, HeadsetCollisionEventArgs e)
         {
+            headsetFade.Fade(Color.black, 0.1f);
             headsetColliding = true;
         }
 
         private void OnHeadsetCollisionEnded(object sender, HeadsetCollisionEventArgs e)
         {
+            headsetFade.Unfade(0.1f);
             headsetColliding = false;
         }
 

--- a/Assets/VRTK/Scripts/VRTK_PlayerPresence.cs
+++ b/Assets/VRTK/Scripts/VRTK_PlayerPresence.cs
@@ -1,6 +1,7 @@
 ﻿namespace VRTK
 {
     using UnityEngine;
+    using System.Collections;
 
     public struct PlayerPresenceEventArgs
     {
@@ -123,7 +124,7 @@
             CreateCollider();
             lastGoodPositionSet = false;
             headset = VRTK_DeviceFinder.HeadsetTransform();
-            InitHeadsetListeners(true);
+            StartCoroutine(WaitForHeadsetCollision(true));
 
             InitControllerListeners(VRTK_SDK_Bridge.GetControllerLeftHand(), true);
             InitControllerListeners(VRTK_SDK_Bridge.GetControllerRightHand(), true);
@@ -137,17 +138,25 @@
             InitControllerListeners(VRTK_SDK_Bridge.GetControllerRightHand(), false);
         }
 
+        private IEnumerator WaitForHeadsetCollision(bool state)
+        {
+            yield return new WaitForEndOfFrame();
+
+            InitHeadsetListeners(state);
+        }
+
         private void InitHeadsetListeners(bool state)
         {
-            if (headset.GetComponent<VRTK_HeadsetCollisionFade>())
+            var headsetCollision = headset.GetComponent<VRTK_HeadsetCollision>();
+            if (headsetCollision)
             {
                 if (state)
                 {
-                    headset.GetComponent<VRTK_HeadsetCollisionFade>().HeadsetCollisionDetect += new HeadsetCollisionEventHandler(OnHeadsetCollision);
+                    headsetCollision.HeadsetCollisionDetect += new HeadsetCollisionEventHandler(OnHeadsetCollision);
                 }
                 else
                 {
-                    headset.GetComponent<VRTK_HeadsetCollisionFade>().HeadsetCollisionDetect -= new HeadsetCollisionEventHandler(OnHeadsetCollision);
+                    headsetCollision.HeadsetCollisionDetect -= new HeadsetCollisionEventHandler(OnHeadsetCollision);
                 }
             }
         }
@@ -182,7 +191,6 @@
         {
             if (resetPositionOnCollision && lastGoodPositionSet)
             {
-                VRTK_SDK_Bridge.HeadsetFade(Color.black, 0f);
                 transform.position = lastGoodPosition;
             }
         }

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -196,6 +196,8 @@ This directory contains all of the toolkit scripts that add VR functionality to 
  * [VRTK_UIPointer](#unity-ui-pointer-vrtk_uipointer)
  * [VRTK_BasicTeleport](#basic-teleporter-vrtk_basicteleport)
  * [VRTK_HeightAdjustTeleport](#height-adjustable-teleporter-vrtk_heightadjustteleport)
+ * [VRTK_HeadsetCollision](#headset-collision-vrtk_headsetcollision)
+ * [VRTK_HeadsetFade](#headset-fade-vrtk_headsetfade)
  * [VRTK_HeadsetCollisionFade](#headset-collision-fade-vrtk_headsetcollisionfade)
  * [VRTK_PlayerPresence](#player-presence-vrtk_playerpresence)
  * [VRTK_TouchpadWalking](#touchpad-movement-vrtk_touchpadwalking)
@@ -912,25 +914,21 @@ Like the basic teleporter the Height Adjust Teleport script is attached to the `
 
 ---
 
-## Headset Collision Fade (VRTK_HeadsetCollisionFade)
+## Headset Collision (VRTK_HeadsetCollision)
 
 ### Overview
 
-The purpose of the Headset Collision Fade is to detect when the user's VR headset collides with another game object and fades the screen to a solid colour. This is to deal with a user putting their head into a game object and seeing the inside of the object clipping, which is an undesired effect.
-
-The reasoning behind this is if the user puts their head where it shouldn't be, then fading to a colour (e.g. black) will make the user realise they've done something wrong and they'll probably naturally step backwards.
+The purpose of the Headset Collision is to detect when the user's VR headset collides with another game object.
 
 If the headset is colliding then the teleport action is also disabled to prevent cheating by clipping through walls.
 
   > **Unity Version Information**
-  > * If using `Unity 5.3` or older then the Headset Collision Fade script is attached to the `Camera (head)` object within the `[CameraRig]` prefab.
-  > * If using `Unity 5.4` or newer then the Headset Collision Fade script is attached to the `Camera (eye)` object within the `[CameraRig]->Camera (head)` prefab.
+  > * If using `Unity 5.3` or older then the Headset Collision script is attached to the `Camera (head)` object within the `[CameraRig]` prefab.
+  > * If using `Unity 5.4` or newer then the Headset Collision script is attached to the `Camera (eye)` object within the `[CameraRig]->Camera (head)` prefab.
 
 ### Inspector Parameters
 
-  * **Blink Transition Speed:** The fade blink speed on collision.
-  * **Fade Color:** The colour to fade the headset to on collision.
-  * **Ignore Target With Tag Or Class:** A string that specifies an object Tag or the name of a Script attached to an object and will prevent the object from fading the headset view on collision.
+  * **Ignore Target With Tag Or Class:** A string that specifies an object Tag or the name of a Script attached to an object and will be ignored on headset collision.
 
 ### Class Events
 
@@ -941,6 +939,120 @@ If the headset is colliding then the teleport action is also disabled to prevent
 
   * `Collider collider` - The Collider of the game object the headset has collided with.
   * `Transform currentTransform` - The current Transform of the object that the Headset Collision Fade script is attached to (Camera).
+
+### Class Methods
+
+#### IsColliding/0
+
+  > `public virtual bool IsColliding()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * `bool` Returns true if the headset is currently colliding with a valid game object.
+
+The IsColliding method is used to determine if the headset is currently colliding with a valid game object and returns true if it is and false if it is not colliding with anything or an invalid game object.
+
+### Example
+
+`VRTK/Examples/011_Camera_HeadSetCollisionFading` has collidable walls around the play area and if the user puts their head into any of the walls then the headset will fade to black.
+
+---
+
+## Headset Fade (VRTK_HeadsetFade)
+
+### Overview
+
+The purpose of the Headset Fade is to change the colour of the headset view to a specified colour over a given duration and to also unfade it back to being transparent. The `Fade` and `Unfade` methods can only be called via another script and this Headset Fade script does not do anything on initialisation to fade or unfade the headset view.
+
+  > **Unity Version Information**
+  > * If using `Unity 5.3` or older then the Headset Fade script is attached to the `Camera (head)` object within the `[CameraRig]` prefab.
+  > * If using `Unity 5.4` or newer then the Headset Fade script is attached to the `Camera (eye)` object within the `[CameraRig]->Camera (head)` prefab.
+
+### Class Events
+
+  * `HeadsetFadeStart` - Emitted when the user's headset begins to fade to a given colour.
+  * `HeadsetFadeComplete` - Emitted when the user's headset has completed the fade and is now fully at the given colour.
+  * `HeadsetUnfadeStart` - Emitted when the user's headset begins to unfade back to a transparent colour.
+  * `HeadsetUnfadeComplete` - Emitted when the user's headset has completed unfading and is now fully transparent again.
+
+#### Event Payload
+
+  * `float timeTillComplete` - A float that is the duration for the fade/unfade process has remaining.
+  * `Transform currentTransform` - The current Transform of the object that the Headset Fade script is attached to (Camera).
+
+### Class Methods
+
+#### IsFaded/0
+
+  > `public virtual bool IsFaded()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * `bool` Returns true if the headset is currently fading or faded.
+
+The IsFaded method returns true if the headset is currently fading or has completely faded and returns false if it is completely unfaded.
+
+#### IsTransitioning/0
+
+  > `public virtual bool IsTransitioning()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * `bool` Returns true if the headset is currently in the process of fading or unfading.
+
+The IsTransitioning method returns true if the headset is currently fading or unfading and returns false if it is completely faded or unfaded.
+
+#### Fade/2
+
+  > `public virtual void Fade(Color color, float duration)`
+
+  * Parameters
+   * `Color color` - The colour to fade the headset view to.
+   * `float duration` - The time in seconds to take to complete the fade transition.
+  * Returns
+   * _none_
+
+The Fade method initiates a change in the colour of the headset view to the given colour over a given duration.
+
+#### Unfade/1
+
+  > `public virtual void Unfade(float duration)`
+
+  * Parameters
+   * `float duration` - The time in seconds to take to complete the unfade transition.
+  * Returns
+   * _none_
+
+The Unfade method initiates the headset to change colour back to a transparent colour over a given duration.
+
+### Example
+
+`VRTK/Examples/011_Camera_HeadSetCollisionFading` has collidable walls around the play area and if the user puts their head into any of the walls then the headset will fade to black.
+
+---
+
+## Headset Collision Fade (VRTK_HeadsetCollisionFade)
+
+### Overview
+
+The purpose of the Headset Collision Fade is to detect when the user's VR headset collides with another game object and fades the screen to a solid colour. This is to deal with a user putting their head into a game object and seeing the inside of the object clipping, which is an undesired effect. The reasoning behind this is if the user puts their head where it shouldn't be, then fading to a colour (e.g. black) will make the user realise they've done something wrong and they'll probably naturally step backwards.
+
+The Headset Collision Fade uses a composition of the Headset Collision and Headset Fade scripts to derrive the desired behaviour.
+
+  > **Unity Version Information**
+  > * If using `Unity 5.3` or older then the Headset Collision Fade script is attached to the `Camera (head)` object within the `[CameraRig]` prefab.
+  > * If using `Unity 5.4` or newer then the Headset Collision Fade script is attached to the `Camera (eye)` object within the `[CameraRig]->Camera (head)` prefab.
+
+### Inspector Parameters
+
+  * **Blink Transition Speed:** The fade blink speed on collision.
+  * **Fade Color:** The colour to fade the headset to on collision.
+  * **Ignore Target With Tag Or Class:** A string that specifies an object Tag or the name of a Script attached to an object and will prevent the object from fading the headset view on collision.
+  
+### Example
 
 `VRTK/Examples/011_Camera_HeadSetCollisionFading` has collidable walls around the play area and if the user puts their head into any of the walls then the headset will fade to black.
 


### PR DESCRIPTION
The Headset Collision Fade script is now just composed of two other
scripts that deal with headset collision and headset fading
independently. This decoupling of the headset collision and headset
fading actions means that more versatile solutions for headset
collision can be implemented.

The Headset Collision script deals with any collisions from the user's
headset and emits the relevant events, whilst the Headset Fade script
deals with fading and unfading the headset view and also emits relevant
events.