### PR TITLE
feat(Editor): add interactable object custom inspector

### DIFF
--- a/Assets/VRTK/Editor.meta
+++ b/Assets/VRTK/Editor.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: f477774704c439042b9a6ab58b50a92a
+folderAsset: yes
+timeCreated: 1472237637
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Editor/VRTK_InteractableObjectEditor.cs
+++ b/Assets/VRTK/Editor/VRTK_InteractableObjectEditor.cs
@@ -1,0 +1,165 @@
+﻿using UnityEngine;
+using UnityEditor;
+using VRTK;
+
+[CustomEditor(typeof(VRTK_InteractableObject), true)]
+public class VRTK_InteractableObjectEditor : Editor
+{
+    private bool viewTouch = true;
+    private bool viewGrab = false;
+    private bool viewUse = false;
+    private bool viewCustom = false;
+
+    public override void OnInspectorGUI()
+    {
+        VRTK_InteractableObject targ = (VRTK_InteractableObject)target;
+        GUILayout.Space(10);
+        GUIStyle guiStyle = EditorStyles.foldout;
+        FontStyle previousStyle = guiStyle.fontStyle;
+        guiStyle.fontStyle = FontStyle.Bold;
+        viewTouch = EditorGUILayout.Foldout(viewTouch, "Touch Options", guiStyle);
+        guiStyle.fontStyle = previousStyle;
+        GUILayout.Space(2);
+        if (viewTouch)
+        {
+            EditorGUI.indentLevel++;
+
+            targ.highlightOnTouch = EditorGUILayout.Toggle("Highlight on Touch:", targ.highlightOnTouch);
+            if (targ.highlightOnTouch)
+            {
+                targ.touchHighlightColor = EditorGUILayout.ColorField("Touch Highlight Color:", targ.touchHighlightColor);
+            }
+
+            GUILayout.BeginHorizontal();
+            EditorGUILayout.PrefixLabel("Rumble on Touch:");
+            EditorGUI.indentLevel--;
+            GUILayout.Label("Strength");
+            float x = EditorGUILayout.FloatField(targ.rumbleOnTouch.x);
+            GUILayout.Label("Duration");
+            float y = EditorGUILayout.FloatField(targ.rumbleOnTouch.y);
+            targ.rumbleOnTouch = new Vector2(y, x);
+            EditorGUI.indentLevel++;
+            GUILayout.EndHorizontal();
+
+            targ.allowedTouchControllers = (VRTK_InteractableObject.AllowedController)EditorGUILayout.EnumPopup("Allowed Touch Controllers:", targ.allowedTouchControllers);
+            targ.hideControllerOnTouch = (VRTK_InteractableObject.ControllerHideMode)EditorGUILayout.EnumPopup("Hide Controller On Touch:", targ.hideControllerOnTouch);
+
+            EditorGUI.indentLevel--;
+        }
+
+        //Grab Layout
+        GUILayout.Space(10);
+        targ.isGrabbable = EditorGUILayout.Toggle("Is Grabbable:", targ.isGrabbable);
+        if (targ.isGrabbable)
+        {
+            guiStyle = EditorStyles.foldout;
+            previousStyle = guiStyle.fontStyle;
+            guiStyle.fontStyle = FontStyle.Bold;
+            viewGrab = EditorGUILayout.Foldout(viewGrab, "Grab Options", guiStyle);
+            guiStyle.fontStyle = previousStyle;
+            GUILayout.Space(2);
+            if (viewGrab)
+            {
+                EditorGUI.indentLevel++;
+
+                targ.isDroppable = EditorGUILayout.Toggle("Is Droppable:", targ.isDroppable);
+                targ.isSwappable = EditorGUILayout.Toggle("Is Swappable:", targ.isSwappable);
+                targ.holdButtonToGrab = EditorGUILayout.Toggle("Hold Button To Grab:", targ.holdButtonToGrab);
+                targ.grabOverrideButton = (VRTK_ControllerEvents.ButtonAlias)EditorGUILayout.EnumPopup("Grab Override Button:", targ.grabOverrideButton);
+
+                GUILayout.BeginHorizontal();
+                EditorGUILayout.PrefixLabel("Rumble on Grab:");
+                EditorGUI.indentLevel--;
+                GUILayout.Label("Strength");
+                float x = EditorGUILayout.FloatField(targ.rumbleOnGrab.x);
+                GUILayout.Label("Duration");
+                float y = EditorGUILayout.FloatField(targ.rumbleOnGrab.y);
+                targ.rumbleOnGrab = new Vector2(y, x);
+                EditorGUI.indentLevel++;
+                GUILayout.EndHorizontal();
+
+                targ.allowedGrabControllers = (VRTK_InteractableObject.AllowedController)EditorGUILayout.EnumPopup("Allowed Controllers:", targ.allowedGrabControllers);
+                targ.precisionSnap = EditorGUILayout.Toggle("Precision Snap:", targ.precisionSnap);
+                if (!targ.precisionSnap)
+                {
+                    targ.rightSnapHandle = EditorGUILayout.ObjectField("Right Snap Handle:", targ.rightSnapHandle, typeof(Transform), true) as Transform;
+                    targ.leftSnapHandle = EditorGUILayout.ObjectField("Left Snap Handle:", targ.leftSnapHandle, typeof(Transform), true) as Transform;
+
+                }
+                targ.hideControllerOnGrab = (VRTK_InteractableObject.ControllerHideMode)EditorGUILayout.EnumPopup("Hide Controller On Grab:", targ.hideControllerOnGrab);
+                targ.stayGrabbedOnTeleport = EditorGUILayout.Toggle("Stay Grabbed on Teleport:", targ.stayGrabbedOnTeleport);
+                targ.grabAttachMechanic = (VRTK_InteractableObject.GrabAttachType)EditorGUILayout.EnumPopup("Grab Attach Mechanic:", targ.grabAttachMechanic);
+                if (targ.grabAttachMechanic == VRTK_InteractableObject.GrabAttachType.Fixed_Joint || targ.grabAttachMechanic == VRTK_InteractableObject.GrabAttachType.Spring_Joint
+                    || targ.grabAttachMechanic == VRTK_InteractableObject.GrabAttachType.Track_Object || targ.grabAttachMechanic == VRTK_InteractableObject.GrabAttachType.Rotator_Track)
+                {
+                    targ.detachThreshold = EditorGUILayout.FloatField("Detach Threshold:", targ.detachThreshold);
+                    if (targ.grabAttachMechanic == VRTK_InteractableObject.GrabAttachType.Spring_Joint)
+                    {
+                        targ.springJointStrength = EditorGUILayout.FloatField("Spring Joint Strength:", targ.springJointStrength);
+                        targ.springJointDamper = EditorGUILayout.FloatField("Spring Joint Damper:", targ.springJointDamper);
+                    }
+                }
+                targ.throwMultiplier = EditorGUILayout.FloatField("Throw Multiplier:", targ.throwMultiplier);
+                targ.onGrabCollisionDelay = EditorGUILayout.FloatField("On Grab Collision Delay:", targ.onGrabCollisionDelay);
+
+                EditorGUI.indentLevel--;
+            }
+        }
+
+        GUILayout.Space(10);
+        targ.isUsable = EditorGUILayout.Toggle("Is Usable:", targ.isUsable);
+        if (targ.isUsable)
+        {
+            guiStyle = EditorStyles.foldout;
+            previousStyle = guiStyle.fontStyle;
+            guiStyle.fontStyle = FontStyle.Bold;
+            viewUse = EditorGUILayout.Foldout(viewUse, "Use Options", guiStyle);
+            guiStyle.fontStyle = previousStyle;
+            GUILayout.Space(2);
+            if (viewUse)
+            {
+                EditorGUI.indentLevel++;
+
+                targ.useOnlyIfGrabbed = EditorGUILayout.Toggle("Use Only If Grabbed: ", targ.useOnlyIfGrabbed);
+                targ.holdButtonToUse = EditorGUILayout.Toggle("Hold Button To Use: ", targ.holdButtonToUse);
+                targ.useOverrideButton = (VRTK_ControllerEvents.ButtonAlias)EditorGUILayout.EnumPopup("Use Override Button:", targ.useOverrideButton);
+                targ.pointerActivatesUseAction = EditorGUILayout.Toggle("Pointer Activates Use Action: ", targ.pointerActivatesUseAction);
+
+                GUILayout.BeginHorizontal();
+                EditorGUILayout.PrefixLabel("Rumble on Grab:");
+                EditorGUI.indentLevel--;
+                GUILayout.Label("Strength");
+                float x = EditorGUILayout.FloatField(targ.rumbleOnGrab.x);
+                GUILayout.Label("Duration");
+                float y = EditorGUILayout.FloatField(targ.rumbleOnGrab.y);
+                targ.rumbleOnGrab = new Vector2(y, x);
+                EditorGUI.indentLevel++;
+                GUILayout.EndHorizontal();
+
+                targ.allowedUseControllers = (VRTK_InteractableObject.AllowedController)EditorGUILayout.EnumPopup("Allowed Use Controllers:", targ.allowedUseControllers);
+                targ.hideControllerOnUse = (VRTK_InteractableObject.ControllerHideMode)EditorGUILayout.EnumPopup("Hide Controller On Use:", targ.hideControllerOnUse);
+
+                EditorGUI.indentLevel--;
+            }
+        }
+
+        if (targ.GetComponent<VRTK_InteractableObject>().GetType().IsSubclassOf(typeof(VRTK_InteractableObject)))
+        {
+            GUILayout.Space(10);
+            guiStyle = EditorStyles.foldout;
+            previousStyle = guiStyle.fontStyle;
+            guiStyle.fontStyle = FontStyle.Bold;
+            viewCustom = EditorGUILayout.Foldout(viewCustom, "Custom Options", guiStyle);
+            guiStyle.fontStyle = previousStyle;
+            GUILayout.Space(2);
+            if (viewCustom)
+            {
+                DrawPropertiesExcluding(serializedObject, new string[] {"hideControllerOnUse","allowedUseControllers","rumbleOnUse","pointerActivatesUseAction","useOverrideButton",
+                    "holdButtonToUse","useOnlyIfGrabbed","throwMultiplier","onGrabCollisionDelay","springJointDamper","springJointStrength","detachThreshold","grabAttachMechanic","stayGrabbedOnTeleport",
+                    "hideControllerOnGrab","leftSnapHandle","rightSnapHandle","precisionSnap","allowedGrabControllers","rumbleOnGrab","grabOverrideButton","holdButtonToGrab","isSwappable","isDroppable",
+                    "isGrabbable","hideControllerOnTouch","allowedTouchControllers","rumbleOnTouch","touchHighlightColor","highlightOnTouch", "isUsable"});
+            }
+        }
+
+    }
+}

--- a/Assets/VRTK/Editor/VRTK_InteractableObjectEditor.cs.meta
+++ b/Assets/VRTK/Editor/VRTK_InteractableObjectEditor.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 8fda0fb84efc44a48b8f55eb735b589e
+timeCreated: 1472237659
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1199,10 +1199,10 @@ The basis of this script is to provide a simple mechanism for identifying object
 
 ### Inspector Parameters
 
-#### Touch Interactions
+#### Touch Options
   * **Highlight On Touch:** The object will only highlight when a controller touches it if this is checked.
   * **Touch Highlight Color:** The colour to highlight the object when it is touched. This colour will override any globally set colour (for instance on the `VRTK_InteractTouch` script).
-  * **Rumble On Touch:** The haptic feedback on the controller can be triggered upon touching the object, the `x` denotes the length of time, the `y` denotes the strength of the pulse. (x and y will be replaced in the future with a custom editor)
+  * **Rumble On Touch:** The haptic feedback on the controller can be triggered upon touching the object, the `Strength` denotes the strength of the pulse, the `Duration` denotes the length of time.
   * **Allowed Touch Controllers:** Determines which controller can initiate a touch action. The options available are:
    * `Both` means both controllers will register a touch.
    * `Left_Only` means only the left controller will register a touch.
@@ -1212,27 +1212,25 @@ The basis of this script is to provide a simple mechanism for identifying object
    * `Override Hide` means hiding the controller when touched, overriding controller settings.
    * `Override Dont Hide` means *not* hiding the controller when touched, overriding controller settings.
 
-#### Grab Interactions
+#### Grab Options
   * **Is Grabbable:** Determines if the object can be grabbed.
   * **Is Droppable:** Determines if the object can be dropped by the controller grab button being used. If this is unchecked then it's not possible to drop the item once it's picked up using the controller button. It is still possible for the item to be dropped if the Grab Attach Mechanic is a joint and too much force is applied to the object and the joint is broken. To prevent this it's better to use the Child Of Controller mechanic.
   * **Is Swappable:** Determines if the object can be swapped between controllers when it is picked up. If it is unchecked then the object must be dropped before it can be picked up by the other controller.
   * **Hold Button To Grab:** If this is checked then the grab button on the controller needs to be continually held down to keep grabbing. If this is unchecked the grab button toggles the grab action with one button press to grab and another to release.
   * **Grab Override Button:** If this is set to `Undefined` then the global grab alias button will grab the object, setting it to any other button will ensure the override button is used to grab this specific interactable object.
-  * **Rumble On Grab:** The haptic feedback on the controller can be triggered upon grabbing the object, the `x` denotes the length of time, the `y` denotes the strength of the pulse. (x and y will be replaced in the future with a custom editor).
+  * **Rumble On Grab:** The haptic feedback on the controller can be triggered upon grabbing the object, the `Strength` denotes the strength of the pulse, the `Duration` denotes the length of time.
   * **Allowed Grab Controllers:** Determines which controller can initiate a grab action. The options available are:
    * `Both` means both controllers are allowed to grab.
    * `Left_Only` means only the left controller is allowed to grab.
    * `Right_Only` means only the right controller is allowed to grab.
   * **Precision_Snap:** If this is checked then when the controller grabs the object, it will grab it with precision and pick it up at the particular point on the object the controller is touching.
-  * **Right Snap Handle:** A Transform provided as an empty game object which must be the child of the item being grabbed and serves as an orientation point to rotate and position the grabbed item in relation to the right handed controller. If no Right Snap Handle is provided but a Left Snap Handle is provided, then the Left Snap Handle will be used in place. If no Snap Handle is provided then the object will be grabbed at its central point.
-  * **Left Snap Handle:** A Transform provided as an empty game object which must be the child of the item being grabbed and serves as an orientation point to rotate and position the grabbed item in relation to the left handed controller. If no Left Snap Handle is provided but a Right Snap Handle is provided, then the Right Snap Handle will be used in place. If no Snap Handle is provided then the object will be grabbed at its central point.
+  * **Right Snap Handle:** A Transform provided as an empty game object which must be the child of the item being grabbed and serves as an orientation point to rotate and position the grabbed item in relation to the right handed controller. If no Right Snap Handle is provided but a Left Snap Handle is provided, then the Left Snap Handle will be used in place. If no Snap Handle is provided then the object will be grabbed at its central point. Not required for `Precision Snap`.
+  * **Left Snap Handle:** A Transform provided as an empty game object which must be the child of the item being grabbed and serves as an orientation point to rotate and position the grabbed item in relation to the left handed controller. If no Left Snap Handle is provided but a Right Snap Handle is provided, then the Right Snap Handle will be used in place. If no Snap Handle is provided then the object will be grabbed at its central point. Not required for `Precision Snap`.
   * **Hide Controller On Grab:** Optionally override the controller setting (hide when grabbed):
    * `Default` means using controller settings.
    * `Override Hide` means hiding the controller when grabbed, overriding controller settings.
    * `Override Dont Hide` means *not* hiding the controller when grabbed, overriding controller settings.
   * **Stay Grabbed On Teleport:** If this is checked then the object will stay grabbed to the controller when a teleport occurs. If it is unchecked then the object will be released when a teleport occurs.
-
-#### Grab Mechanics
   * **Grab Attach Type:** This determines how the grabbed item will be attached to the controller when it is grabbed.
    * `Fixed Joint` attaches the object to the controller with a fixed joint meaning it tracks the position and rotation of the controller with perfect 1:1 tracking.
    * `Spring Joint` attaches the object to the controller with a spring joint meaning there is some flexibility between the item and the controller force moving the item. This works well when attempting to pull an item rather than snap the item directly to the controller. It creates the illusion that the item has resistance to move it.
@@ -1240,19 +1238,19 @@ The basis of this script is to provide a simple mechanism for identifying object
    * `Rotator Track` also tracks the object but instead of the object tracking the direction of the controller, a force is applied to the object to cause it to rotate. This is ideal for hinged joints on items such as wheels or doors.
    * `Child Of Controller` simply makes the object a child of the controller grabbing so it naturally tracks the position of the controller motion.
    * `Climbable` non-rigid body interactable object used to allow player climbing.
-  * **Detach Threshold:** The force amount when to detach the object from the grabbed controller. If the controller tries to exert a force higher than this threshold on the object (from pulling it through another object or pushing it into another object) then the joint holding the object to the grabbing controller will break and the object will no longer be grabbed. This also works with Tracked Object grabbing but determines how far the controller is from the object before breaking the grab.
-  * **Spring Joint Strength:** The strength of the spring holding the object to the controller. A low number will mean the spring is very loose and the object will require more force to move it, a high number will mean a tight spring meaning less force is required to move it.
-  * **Spring Joint Damper:** The amount to damper the spring effect when using a Spring Joint grab mechanic. A higher number here will reduce the oscillation effect when moving jointed Interactable Objects.
+  * **Detach Threshold:** The force amount when to detach the object from the grabbed controller. If the controller tries to exert a force higher than this threshold on the object (from pulling it through another object or pushing it into another object) then the joint holding the object to the grabbing controller will break and the object will no longer be grabbed. This also works with Tracked Object grabbing but determines how far the controller is from the object before breaking the grab. Only required for `Fixed Joint`, `Spring Joint`, `Track Object` and `Rotator Track`.
+  * **Spring Joint Strength:** The strength of the spring holding the object to the controller. A low number will mean the spring is very loose and the object will require more force to move it, a high number will mean a tight spring meaning less force is required to move it. Only required for `Spring Joint`.
+  * **Spring Joint Damper:** The amount to damper the spring effect when using a Spring Joint grab mechanic. A higher number here will reduce the oscillation effect when moving jointed Interactable Objects. Only required for `Spring Joint`.
   * **Throw Multiplier:** An amount to multiply the velocity of the given object when it is thrown. This can also be used in conjunction with the Interact Grab Throw Multiplier to have certain objects be thrown even further than normal (or thrown a shorter distance if a number below 1 is entered).
   * **On Grab Collision Delay:** The amount of time to delay collisions affecting the object when it is first grabbed. This is useful if a game object may get stuck inside another object when it is being grabbed.
 
-#### Use Interactions
+#### Use Options
   * **Is Usable:** Determines if the object can be used.
   * **Use Only If Grabbed:** If this is checked the object can be used only if it was grabbed before.
   * **Hold Button To Use:** If this is checked then the use button on the controller needs to be continually held down to keep using. If this is unchecked the the use button toggles the use action with one button press to start using and another to stop using.
   * **Use Override Button:** If this is set to `Undefined` then the global use alias button will use the object, setting it to any other button will ensure the override button is used to use this specific interactable object.
   * **Pointer Activates Use Action:** If this is checked then when a World Pointer beam (projected from the controller) hits the interactable object, if the object has `Hold Button To Use` unchecked then whilst the pointer is over the object it will run it's `Using` method. If `Hold Button To Use` is unchecked then the `Using` method will be run when the pointer is deactivated. The world pointer will not throw the `Destination Set` event if it is affecting an interactable object with this setting checked as this prevents unwanted teleporting from happening when using an object with a pointer.
-  * **Rumble On Use:** The haptic feedback on the controller can be triggered upon using the object, the `x` denotes the length of time, the `y` denotes the strength of the pulse. (x and y will be replaced in the future with a custom editor).
+  * **Rumble On Use:** The haptic feedback on the controller can be triggered upon using the object, the `Strength` denotes the strength of the pulse, the `Duration` denotes the length of time.
   * **Allowed Use Controllers:** Determines which controller can initiate a use action. The options available are:
    * `Both` means both controllers are allowed to use.
    * `Left_Only` means only the left controller is allowed to use.


### PR DESCRIPTION
The Interactable Object now has a custom Unity inspector to arrange the
parameters in a more accessible way by grouping things in foldouts and
only showing certain foldouts and parameters if they are required.