### PR TITLE
fix(Interaction): detachment check from grab point

### DIFF
--- a/Assets/VRTK/Scripts/VRTK_InteractableObject.cs
+++ b/Assets/VRTK/Scripts/VRTK_InteractableObject.cs
@@ -584,7 +584,7 @@ namespace VRTK
         {
             if (trackPoint)
             {
-                float distance = Vector3.Distance(trackPoint.position, transform.position);
+                float distance = Vector3.Distance(trackPoint.position, originalControllerAttachPoint.position);
                 if (distance > (detachThreshold / 1000))
                 {
                     ForceReleaseGrab();


### PR DESCRIPTION
Check detachment from grab point instead of transform so big objects don't release immediately if grabbed from a point far from the transform origin