### PR TITLE
fix(Interaction): only instance materials if highlight is used

### DIFF
--- a/Assets/VRTK/Scripts/VRTK_InteractableObject.cs
+++ b/Assets/VRTK/Scripts/VRTK_InteractableObject.cs
@@ -264,6 +264,11 @@ namespace VRTK
                     Color color = (touchHighlightColor != Color.clear ? touchHighlightColor : globalHighlightColor);
                     if (color != Color.clear)
                     {
+                        if (originalObjectColours == null)
+                        {
+                            originalObjectColours = StoreOriginalColors();
+                        }
+
                         var colorArray = BuildHighlightColorArray(color);
                         ChangeColor(colorArray);
                     }
@@ -421,7 +426,10 @@ namespace VRTK
 
         protected virtual void Start()
         {
-            originalObjectColours = StoreOriginalColors();
+            if (highlightOnTouch)
+            {
+                originalObjectColours = StoreOriginalColors();
+            }
         }
 
         protected virtual void Update()


### PR DESCRIPTION
VRTK_Interactable object grabs each material to change the color
if highlighting is used. This breaks batching support in Unity
and so it is now only set if highlighting is actually used.