### PR TITLE
feat(Simple Pointer) add hit normal to marker and related class

### DIFF
--- a/Assets/VRTK/Examples/Resources/Scripts/ModelVillage_TeleportLocation.cs
+++ b/Assets/VRTK/Examples/Resources/Scripts/ModelVillage_TeleportLocation.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using VRTK;
 
 public class ModelVillage_TeleportLocation : VRTK_DestinationMarker
@@ -15,7 +15,7 @@ public class ModelVillage_TeleportLocation : VRTK_DestinationMarker
             {
                 var distance = Vector3.Distance(transform.position, destination.position);
                 var controllerIndex = VRTK_DeviceFinder.GetControllerIndex(controller.gameObject);
-                OnDestinationMarkerSet(SetDestinationMarkerEvent(distance, destination, destination.position, controllerIndex));
+                OnDestinationMarkerSet(SetDestinationMarkerEvent(distance, destination, destination.position, Vector3.zero, controllerIndex));
             }
             lastUsePressedState = controller.usePressed;
         }

--- a/Assets/VRTK/Scripts/Abstractions/VRTK_DestinationMarker.cs
+++ b/Assets/VRTK/Scripts/Abstractions/VRTK_DestinationMarker.cs
@@ -27,6 +27,7 @@ namespace VRTK
         public float distance;
         public Transform target;
         public Vector3 destinationPosition;
+        public Vector3 destinationHitNormal;
         public bool enableTeleport;
         public uint controllerIndex;
     }
@@ -84,13 +85,14 @@ namespace VRTK
             headsetPositionCompensation = state;
         }
 
-        protected DestinationMarkerEventArgs SetDestinationMarkerEvent(float distance, Transform target, Vector3 position, uint controllerIndex)
+        protected DestinationMarkerEventArgs SetDestinationMarkerEvent(float distance, Transform target, Vector3 position, Vector3 positionHitNormal, uint controllerIndex)
         {
             DestinationMarkerEventArgs e;
             e.controllerIndex = controllerIndex;
             e.distance = distance;
             e.target = target;
             e.destinationPosition = position;
+            e.destinationHitNormal = positionHitNormal;
             e.enableTeleport = enableTeleport;
             return e;
         }

--- a/Assets/VRTK/Scripts/Abstractions/VRTK_WorldPointer.cs
+++ b/Assets/VRTK/Scripts/Abstractions/VRTK_WorldPointer.cs
@@ -30,6 +30,7 @@ namespace VRTK
         public float activateDelay = 0f;
 
         protected Vector3 destinationPosition;
+        protected Vector3 destinationHitNormal = Vector3.zero;
         protected float pointerContactDistance = 0f;
         protected Transform pointerContactTarget = null;
         protected uint controllerIndex;
@@ -181,7 +182,7 @@ namespace VRTK
                 return;
             }
 
-            OnDestinationMarkerEnter(SetDestinationMarkerEvent(pointerContactDistance, pointerContactTarget, destinationPosition, controllerIndex));
+            OnDestinationMarkerEnter(SetDestinationMarkerEvent(pointerContactDistance, pointerContactTarget, destinationPosition, destinationHitNormal, controllerIndex));
             StartUseAction(pointerContactTarget);
         }
 
@@ -192,7 +193,7 @@ namespace VRTK
                 return;
             }
 
-            OnDestinationMarkerExit(SetDestinationMarkerEvent(pointerContactDistance, pointerContactTarget, destinationPosition, controllerIndex));
+            OnDestinationMarkerExit(SetDestinationMarkerEvent(pointerContactDistance, pointerContactTarget, destinationPosition, destinationHitNormal, controllerIndex));
             StopUseAction();
         }
 
@@ -220,7 +221,7 @@ namespace VRTK
 
             if (!playAreaCursorCollided && !PointerActivatesUseAction(interactableObject))
             {
-                OnDestinationMarkerSet(SetDestinationMarkerEvent(pointerContactDistance, pointerContactTarget, destinationPosition, controllerIndex));
+                OnDestinationMarkerSet(SetDestinationMarkerEvent(pointerContactDistance, pointerContactTarget, destinationPosition, destinationHitNormal, controllerIndex));
             }
 
             if (!isActive)

--- a/Assets/VRTK/Scripts/VRTK_SimplePointer.cs
+++ b/Assets/VRTK/Scripts/VRTK_SimplePointer.cs
@@ -1,4 +1,4 @@
-﻿//====================================================================================
+//====================================================================================
 //
 // Purpose: Provide basic laser pointer to VR Controller
 //
@@ -165,6 +165,7 @@ namespace VRTK
                 pointerContactDistance = 0f;
                 pointerContactTarget = null;
                 destinationPosition = Vector3.zero;
+                destinationHitNormal = Vector3.zero;
 
                 UpdatePointerMaterial(pointerMissColor);
             }
@@ -175,6 +176,7 @@ namespace VRTK
                 pointerContactDistance = collidedWith.distance;
                 pointerContactTarget = collidedWith.transform;
                 destinationPosition = pointerTip.transform.position;
+                destinationHitNormal = collidedWith.normal;
 
                 UpdatePointerMaterial(pointerHitColor);
 


### PR DESCRIPTION
Sometime its useful to get the hit normal / surface direction from
the DestinationMarkerEventArgs, for instance in drawing applications
or when you want to orient objects to align with the pointer hit
surface.