### PR TITLE
fix(Interaction): use game object instance id as ref for highlighting - resolves #466

### DIFF
--- a/Assets/VRTK/Scripts/VRTK_InteractableObject.cs
+++ b/Assets/VRTK/Scripts/VRTK_InteractableObject.cs
@@ -528,14 +528,15 @@ namespace VRTK
             var colors = new Dictionary<string, Color[]>();
             foreach (Renderer renderer in GetRendererArray())
             {
-                colors[renderer.gameObject.name] = new Color[renderer.materials.Length];
+                var objectReference = renderer.gameObject.GetInstanceID().ToString();
+                colors[objectReference] = new Color[renderer.materials.Length];
 
                 for (int i = 0; i < renderer.materials.Length; i++)
                 {
                     var material = renderer.materials[i];
                     if (material.HasProperty("_Color"))
                     {
-                        colors[renderer.gameObject.name][i] = material.color;
+                        colors[objectReference][i] = material.color;
                     }
                 }
             }
@@ -547,13 +548,14 @@ namespace VRTK
             var colors = new Dictionary<string, Color[]>();
             foreach (Renderer renderer in GetRendererArray())
             {
-                colors[renderer.gameObject.name] = new Color[renderer.materials.Length];
+                var objectReference = renderer.gameObject.GetInstanceID().ToString();
+                colors[objectReference] = new Color[renderer.materials.Length];
                 for (int i = 0; i < renderer.materials.Length; i++)
                 {
                     var material = renderer.materials[i];
                     if (material.HasProperty("_Color"))
                     {
-                        colors[renderer.gameObject.name][i] = color;
+                        colors[objectReference][i] = color;
                     }
                 }
             }
@@ -564,7 +566,8 @@ namespace VRTK
         {
             foreach (Renderer renderer in GetRendererArray())
             {
-                if (!colors.ContainsKey(renderer.gameObject.name))
+                var objectReference = renderer.gameObject.GetInstanceID().ToString();
+                if (!colors.ContainsKey(objectReference))
                 {
                     continue;
                 }
@@ -574,7 +577,7 @@ namespace VRTK
                     var material = renderer.materials[i];
                     if (material.HasProperty("_Color"))
                     {
-                        material.color = colors[renderer.gameObject.name][i];
+                        material.color = colors[objectReference][i];
                     }
                 }
             }


### PR DESCRIPTION
Previously, the game object when highlighted would use the name of the
game object to store a reference to it's original colour. However, if
child game objects shared the same name then this would break and cause
a crash with the highlighting.

This fix ensures a unique reference to the game object is used, which
is the instance ID of the game object.