### PR TITLE
fix(Teleport): add floor height tolerance parameter - resolves #489

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -951,6 +951,7 @@ Like the basic teleporter the Height Adjust Teleport script is attached to the `
   * **Use Gravity**: allows for gravity based falling when the distance is greater than `Gravity Fall Height`.
   * **Gravity Fall Height**: Fall distance needed before gravity based falling can be triggered.
   * **Blink Y Threshold:** The `y` distance between the floor and the headset that must change before the fade transition is initiated. If the new user location is at a higher distance than the threshold then the headset blink transition will activate on teleport. If the new user location is within the threshold then no blink transition will happen, which is useful for walking up slopes, meshes and terrains where constant blinking would be annoying.
+  * **Floor Height Tolerance:** The amount the `y` position needs to change by between the current floor `y` position and the previous floor `y` position before a change in floor height is considered to have occurred. A higher value here will mean that a `Drop To Floor` teleport event will be less likely to happen if the `y` of the floor beneath the user hasn't changed as much as the given threshold.
 
 ### Example
 


### PR DESCRIPTION
The `Floor Height Tolerance` parameter is used to determine how much
of a change between the current floor `y` and the previous floor `y`
has happened before considering it valid to drop to the nearest floor.

This setting can be used to prevent unnecessary teleport events when
the floor below the user is uneven but should not be considered
different enough to force the user to drop to a new location on such
a small variation change in their `y` position.