### PR TITLE
feat(Caching): add object cache to reduce expensive find calls - resolves #501

### DIFF
--- a/Assets/VRTK/SDK/SteamVR/VRTK_SDK_Bridge.cs
+++ b/Assets/VRTK/SDK/SteamVR/VRTK_SDK_Bridge.cs
@@ -94,11 +94,15 @@
 
         public static Transform GetHeadset()
         {
+            if (cachedHeadset == null)
+            {
 #if (UNITY_5_4_OR_NEWER)
-            return FindObjectOfType<SteamVR_Camera>().GetComponent<Transform>();
+                cachedHeadset = FindObjectOfType<SteamVR_Camera>().GetComponent<Transform>();
 #else
-            return FindObjectOfType<SteamVR_GameView>().GetComponent<Transform>();
+                cachedHeadset = FindObjectOfType<SteamVR_GameView>().GetComponent<Transform>();
 #endif
+            }
+            return cachedHeadset;
         }
 
         public static Transform GetHeadsetCamera()

--- a/Assets/VRTK/Scripts/Abstractions/VRTK_DestinationMarker.cs
+++ b/Assets/VRTK/Scripts/Abstractions/VRTK_DestinationMarker.cs
@@ -84,6 +84,16 @@ namespace VRTK
             headsetPositionCompensation = state;
         }
 
+        protected virtual void OnEnable()
+        {
+            VRTK_ObjectCache.registeredDestinationMarkers.Add(this);
+        }
+
+        protected virtual void OnDisable()
+        {
+            VRTK_ObjectCache.registeredDestinationMarkers.Remove(this);
+        }
+
         protected DestinationMarkerEventArgs SetDestinationMarkerEvent(float distance, Transform target, Vector3 position, uint controllerIndex)
         {
             DestinationMarkerEventArgs e;

--- a/Assets/VRTK/Scripts/Abstractions/VRTK_WorldPointer.cs
+++ b/Assets/VRTK/Scripts/Abstractions/VRTK_WorldPointer.cs
@@ -100,8 +100,9 @@ namespace VRTK
             playAreaCursorBoundaries = new GameObject[4];
         }
 
-        protected virtual void OnEnable()
+        protected override void OnEnable()
         {
+            base.OnEnable();
             controller.AliasPointerOn += new ControllerInteractionEventHandler(EnablePointerBeam);
             controller.AliasPointerOff += new ControllerInteractionEventHandler(DisablePointerBeam);
             controller.AliasPointerSet += new ControllerInteractionEventHandler(SetPointerDestination);
@@ -116,8 +117,9 @@ namespace VRTK
             pointerMaterial.color = pointerMissColor;
         }
 
-        protected virtual void OnDisable()
+        protected override void OnDisable()
         {
+            base.OnDisable();
             DisableBeam();
             destinationSetActive = false;
             pointerContactDistance = 0f;

--- a/Assets/VRTK/Scripts/Helper/VRTK_ObjectCache.cs
+++ b/Assets/VRTK/Scripts/Helper/VRTK_ObjectCache.cs
@@ -1,0 +1,12 @@
+﻿namespace VRTK
+{
+    using UnityEngine;
+    using System.Collections.Generic;
+
+    public class VRTK_ObjectCache : MonoBehaviour
+    {
+        public static List<VRTK_BasicTeleport> registeredTeleporters = new List<VRTK_BasicTeleport>();
+        public static List<VRTK_DestinationMarker> registeredDestinationMarkers = new List<VRTK_DestinationMarker>();
+        public static VRTK_HeadsetCollision registeredHeadsetCollider = null;
+    }
+}

--- a/Assets/VRTK/Scripts/Helper/VRTK_ObjectCache.cs.meta
+++ b/Assets/VRTK/Scripts/Helper/VRTK_ObjectCache.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 3f413a3442bd36946882ab88b99fa98d
+timeCreated: 1472912275
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/VRTK_ControllerActions.cs
+++ b/Assets/VRTK/Scripts/VRTK_ControllerActions.cs
@@ -12,8 +12,8 @@
         private uint controllerIndex;
         private ushort maxHapticVibration = 3999;
         private bool controllerHighlighted = false;
-
         private Dictionary<GameObject, Material> storedMaterials;
+        private Dictionary<string, Transform> cachedElements;
 
         public bool IsControllerVisible()
         {
@@ -140,7 +140,7 @@
 
         public void ToggleHighlightTrigger(bool state, Color? highlight = null, float duration = 0f)
         {
-            if(!state && controllerHighlighted)
+            if (!state && controllerHighlighted)
             {
                 return;
             }
@@ -212,6 +212,7 @@
         {
             gameObject.layer = LayerMask.NameToLayer("Ignore Raycast");
             storedMaterials = new Dictionary<GameObject, Material>();
+            cachedElements = new Dictionary<string, Transform>();
         }
 
         private void Update()
@@ -248,9 +249,18 @@
             }
         }
 
+        private Transform GetElementTransform(string path)
+        {
+            if (!cachedElements.ContainsKey(path))
+            {
+                cachedElements[path] = transform.Find(path);
+            }
+            return cachedElements[path];
+        }
+
         private void ToggleHighlightAlias(bool state, string transformPath, Color? highlight, float duration = 0f)
         {
-            var element = transform.Find(transformPath);
+            var element = GetElementTransform(transformPath);
             if (element)
             {
                 ToggleHighlightControllerElement(state, element.gameObject, highlight, duration);

--- a/Assets/VRTK/Scripts/VRTK_HeadsetCollision.cs
+++ b/Assets/VRTK/Scripts/VRTK_HeadsetCollision.cs
@@ -42,6 +42,7 @@
 
         private void OnEnable()
         {
+            VRTK_ObjectCache.registeredHeadsetCollider = this;
             headsetColliding = false;
             Utilities.SetPlayerObject(gameObject, VRTK_PlayerObject.ObjectTypes.Headset);
 
@@ -56,6 +57,7 @@
 
         private void OnDisable()
         {
+            VRTK_ObjectCache.registeredHeadsetCollider = null;
             headsetColliding = false;
             Destroy(gameObject.GetComponent<BoxCollider>());
             Destroy(gameObject.GetComponent<Rigidbody>());

--- a/Assets/VRTK/Scripts/VRTK_InteractableObject.cs
+++ b/Assets/VRTK/Scripts/VRTK_InteractableObject.cs
@@ -395,11 +395,7 @@ namespace VRTK
 
         public void RegisterTeleporters()
         {
-            foreach (var teleporter in FindObjectsOfType<VRTK_BasicTeleport>())
-            {
-                teleporter.Teleporting += new TeleportEventHandler(OnTeleporting);
-                teleporter.Teleported += new TeleportEventHandler(OnTeleported);
-            }
+            StartCoroutine(RegisterTeleportersAtEndOfFrame());
         }
 
         protected virtual void Awake()
@@ -460,7 +456,7 @@ namespace VRTK
 
         protected virtual void OnDisable()
         {
-            foreach (var teleporter in FindObjectsOfType<VRTK_BasicTeleport>())
+            foreach (var teleporter in VRTK_ObjectCache.registeredTeleporters)
             {
                 teleporter.Teleporting -= new TeleportEventHandler(OnTeleporting);
                 teleporter.Teleported -= new TeleportEventHandler(OnTeleported);
@@ -701,6 +697,16 @@ namespace VRTK
             if (stayGrabbedOnTeleport && AttachIsTrackObject() && trackPoint)
             {
                 transform.position = grabbingObject.transform.position;
+            }
+        }
+
+        private IEnumerator RegisterTeleportersAtEndOfFrame()
+        {
+            yield return new WaitForEndOfFrame();
+            foreach (var teleporter in VRTK_ObjectCache.registeredTeleporters)
+            {
+                teleporter.Teleporting += new TeleportEventHandler(OnTeleporting);
+                teleporter.Teleported += new TeleportEventHandler(OnTeleported);
             }
         }
 


### PR DESCRIPTION
Rather than use `Find` `FindChild` and `FindObjectOfType` when looking
up required objects, the system now has a new Cache static object that
has scripts register with and then other scripts can use this cache
rather than making expensive find calls.