### PR TITLE
feat(Events): add unity events helper scripts for delegate events

### DIFF
--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_BasicTeleport_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_BasicTeleport_UnityEvents.cs
@@ -1,0 +1,56 @@
+﻿using UnityEngine;
+using UnityEngine.Events;
+using VRTK;
+
+[RequireComponent(typeof(VRTK_BasicTeleport))]
+public class VRTK_BasicTeleport_UnityEvents : MonoBehaviour
+{
+    private VRTK_BasicTeleport bt;
+
+    [System.Serializable]
+    public class UnityObjectEvent : UnityEvent<DestinationMarkerEventArgs> { };
+    public UnityObjectEvent OnTeleporting;
+    public UnityObjectEvent OnTeleported;
+
+    private void SetBasicTeleport()
+    {
+        if (bt == null)
+        {
+            bt = GetComponent<VRTK_BasicTeleport>();
+        }
+    }
+
+    private void OnEnable()
+    {
+        SetBasicTeleport();
+        if (bt == null)
+        {
+            Debug.LogError("The VRTK_BasicTeleport_UnityEvents script requires to be attached to a GameObject that contains a VRTK_BasicTeleport script");
+            return;
+        }
+
+        bt.Teleporting += Teleporting;
+        bt.Teleported += Teleported;
+    }
+
+    private void Teleporting(object o, DestinationMarkerEventArgs e)
+    {
+        OnTeleporting.Invoke(e);
+    }
+
+    private void Teleported(object o, DestinationMarkerEventArgs e)
+    {
+        OnTeleported.Invoke(e);
+    }
+
+    private void OnDisable()
+    {
+        if (bt == null)
+        {
+            return;
+        }
+
+        bt.Teleporting += Teleporting;
+        bt.Teleported += Teleported;
+    }
+}

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_BasicTeleport_UnityEvents.cs.meta
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_BasicTeleport_UnityEvents.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 6a5b9ffe9b896854886ce4e3c883f0b5
+timeCreated: 1472928712
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_ControllerEvents_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_ControllerEvents_UnityEvents.cs
@@ -1,0 +1,272 @@
+﻿using UnityEngine;
+using UnityEngine.Events;
+using VRTK;
+
+[RequireComponent(typeof(VRTK_ControllerEvents))]
+public class VRTK_ControllerEvents_UnityEvents : MonoBehaviour
+{
+    private VRTK_ControllerEvents ce;
+
+    [System.Serializable]
+    public class UnityObjectEvent : UnityEvent<ControllerInteractionEventArgs> { };
+    public UnityObjectEvent OnTriggerPressed;
+    public UnityObjectEvent OnTriggerReleased;
+    public UnityObjectEvent OnTriggerTouchStart;
+    public UnityObjectEvent OnTriggerTouchEnd;
+    public UnityObjectEvent OnTriggerHairlineStart;
+    public UnityObjectEvent OnTriggerHairlineEnd;
+    public UnityObjectEvent OnTriggerClicked;
+    public UnityObjectEvent OnTriggerUnclicked;
+    public UnityObjectEvent OnTriggerAxisChanged;
+    public UnityObjectEvent OnApplicationMenuPressed;
+    public UnityObjectEvent OnApplicationMenuReleased;
+    public UnityObjectEvent OnGripPressed;
+    public UnityObjectEvent OnGripReleased;
+    public UnityObjectEvent OnTouchpadPressed;
+    public UnityObjectEvent OnTouchpadReleased;
+    public UnityObjectEvent OnTouchpadTouchStart;
+    public UnityObjectEvent OnTouchpadTouchEnd;
+    public UnityObjectEvent OnTouchpadAxisChanged;
+    public UnityObjectEvent OnAliasPointerOn;
+    public UnityObjectEvent OnAliasPointerOff;
+    public UnityObjectEvent OnAliasPointerSet;
+    public UnityObjectEvent OnAliasGrabOn;
+    public UnityObjectEvent OnAliasGrabOff;
+    public UnityObjectEvent OnAliasUseOn;
+    public UnityObjectEvent OnAliasUseOff;
+    public UnityObjectEvent OnAliasUIClickOn;
+    public UnityObjectEvent OnAliasUIClickOff;
+    public UnityObjectEvent OnAliasMenuOn;
+    public UnityObjectEvent OnAliasMenuOff;
+
+    private void SetControllerEvents()
+    {
+        if (ce == null)
+        {
+            ce = GetComponent<VRTK_ControllerEvents>();
+        }
+    }
+
+    private void OnEnable()
+    {
+        SetControllerEvents();
+        if (ce == null)
+        {
+            Debug.LogError("The VRTK_ControllerEvents_UnityEvents script requires to be attached to a GameObject that contains a VRTK_ControllerEvents script");
+            return;
+        }
+
+        ce.TriggerPressed += TriggerPressed;
+        ce.TriggerReleased += TriggerReleased;
+        ce.TriggerTouchStart += TriggerTouchStart;
+        ce.TriggerTouchEnd += TriggerTouchEnd;
+        ce.TriggerHairlineStart += TriggerHairlineStart;
+        ce.TriggerHairlineEnd += TriggerHairlineEnd;
+        ce.TriggerClicked += TriggerClicked;
+        ce.TriggerUnclicked += TriggerUnclicked;
+        ce.TriggerAxisChanged += TriggerAxisChanged;
+        ce.ApplicationMenuPressed += ApplicationMenuPressed;
+        ce.ApplicationMenuReleased += ApplicationMenuReleased;
+        ce.GripPressed += GripPressed;
+        ce.GripReleased += GripReleased;
+        ce.TouchpadPressed += TouchpadPressed;
+        ce.TouchpadReleased += TouchpadReleased;
+        ce.TouchpadTouchStart += TouchpadTouchStart;
+        ce.TouchpadTouchEnd += TouchpadTouchEnd;
+        ce.TouchpadAxisChanged += TouchpadAxisChanged;
+        ce.AliasPointerOn += AliasPointerOn;
+        ce.AliasPointerOff += AliasPointerOff;
+        ce.AliasPointerSet += AliasPointerSet;
+        ce.AliasGrabOn += AliasGrabOn;
+        ce.AliasGrabOff += AliasGrabOff;
+        ce.AliasUseOn += AliasUseOn;
+        ce.AliasUseOff += AliasUseOff;
+        ce.AliasUIClickOn += AliasUIClickOn;
+        ce.AliasUIClickOff += AliasUIClickOff;
+        ce.AliasMenuOn += AliasMenuOn;
+        ce.AliasMenuOff += AliasMenuOff;
+    }
+
+    private void TriggerPressed(object o, ControllerInteractionEventArgs e)
+    {
+        OnTriggerPressed.Invoke(e);
+    }
+
+    private void TriggerReleased(object o, ControllerInteractionEventArgs e)
+    {
+        OnTriggerReleased.Invoke(e);
+    }
+
+    private void TriggerTouchStart(object o, ControllerInteractionEventArgs e)
+    {
+        OnTriggerTouchStart.Invoke(e);
+    }
+
+    private void TriggerTouchEnd(object o, ControllerInteractionEventArgs e)
+    {
+        OnTriggerTouchEnd.Invoke(e);
+    }
+
+    private void TriggerHairlineStart(object o, ControllerInteractionEventArgs e)
+    {
+        OnTriggerHairlineStart.Invoke(e);
+    }
+
+    private void TriggerHairlineEnd(object o, ControllerInteractionEventArgs e)
+    {
+        OnTriggerHairlineEnd.Invoke(e);
+    }
+
+    private void TriggerClicked(object o, ControllerInteractionEventArgs e)
+    {
+        OnTriggerClicked.Invoke(e);
+    }
+
+    private void TriggerUnclicked(object o, ControllerInteractionEventArgs e)
+    {
+        OnTriggerUnclicked.Invoke(e);
+    }
+
+    private void TriggerAxisChanged(object o, ControllerInteractionEventArgs e)
+    {
+        OnTriggerAxisChanged.Invoke(e);
+    }
+
+    private void ApplicationMenuPressed(object o, ControllerInteractionEventArgs e)
+    {
+        OnApplicationMenuPressed.Invoke(e);
+    }
+
+    private void ApplicationMenuReleased(object o, ControllerInteractionEventArgs e)
+    {
+        OnApplicationMenuReleased.Invoke(e);
+    }
+
+    private void GripPressed(object o, ControllerInteractionEventArgs e)
+    {
+        OnGripPressed.Invoke(e);
+    }
+
+    private void GripReleased(object o, ControllerInteractionEventArgs e)
+    {
+        OnGripReleased.Invoke(e);
+    }
+
+    private void TouchpadPressed(object o, ControllerInteractionEventArgs e)
+    {
+        OnTouchpadPressed.Invoke(e);
+    }
+
+    private void TouchpadReleased(object o, ControllerInteractionEventArgs e)
+    {
+        OnTouchpadReleased.Invoke(e);
+    }
+
+    private void TouchpadTouchStart(object o, ControllerInteractionEventArgs e)
+    {
+        OnTouchpadTouchStart.Invoke(e);
+    }
+
+    private void TouchpadTouchEnd(object o, ControllerInteractionEventArgs e)
+    {
+        OnTouchpadTouchEnd.Invoke(e);
+    }
+
+    private void TouchpadAxisChanged(object o, ControllerInteractionEventArgs e)
+    {
+        OnTouchpadAxisChanged.Invoke(e);
+    }
+
+    private void AliasPointerOn(object o, ControllerInteractionEventArgs e)
+    {
+        OnAliasPointerOn.Invoke(e);
+    }
+
+    private void AliasPointerOff(object o, ControllerInteractionEventArgs e)
+    {
+        OnAliasPointerOff.Invoke(e);
+    }
+
+    private void AliasPointerSet(object o, ControllerInteractionEventArgs e)
+    {
+        OnAliasPointerSet.Invoke(e);
+    }
+
+    private void AliasGrabOn(object o, ControllerInteractionEventArgs e)
+    {
+        OnAliasGrabOn.Invoke(e);
+    }
+
+    private void AliasGrabOff(object o, ControllerInteractionEventArgs e)
+    {
+        OnAliasGrabOff.Invoke(e);
+    }
+
+    private void AliasUseOn(object o, ControllerInteractionEventArgs e)
+    {
+        OnAliasUseOn.Invoke(e);
+    }
+
+    private void AliasUseOff(object o, ControllerInteractionEventArgs e)
+    {
+        OnAliasUseOff.Invoke(e);
+    }
+
+    private void AliasUIClickOn(object o, ControllerInteractionEventArgs e)
+    {
+        OnAliasUIClickOn.Invoke(e);
+    }
+
+    private void AliasUIClickOff(object o, ControllerInteractionEventArgs e)
+    {
+        OnAliasUIClickOff.Invoke(e);
+    }
+
+    private void AliasMenuOn(object o, ControllerInteractionEventArgs e)
+    {
+        OnAliasMenuOn.Invoke(e);
+    }
+
+    private void AliasMenuOff(object o, ControllerInteractionEventArgs e)
+    {
+        OnAliasMenuOff.Invoke(e);
+    }
+
+    private void OnDisable()
+    {
+        if (ce == null)
+        {
+            return;
+        }
+
+        ce.TriggerPressed -= TriggerPressed;
+        ce.TriggerReleased -= TriggerReleased;
+        ce.TriggerTouchStart -= TriggerTouchStart;
+        ce.TriggerTouchEnd -= TriggerTouchEnd;
+        ce.TriggerHairlineStart -= TriggerHairlineStart;
+        ce.TriggerHairlineEnd -= TriggerHairlineEnd;
+        ce.TriggerClicked -= TriggerClicked;
+        ce.TriggerUnclicked -= TriggerUnclicked;
+        ce.TriggerAxisChanged -= TriggerAxisChanged;
+        ce.ApplicationMenuPressed -= ApplicationMenuPressed;
+        ce.ApplicationMenuReleased -= ApplicationMenuReleased;
+        ce.GripPressed -= GripPressed;
+        ce.GripReleased -= GripReleased;
+        ce.TouchpadPressed -= TouchpadPressed;
+        ce.TouchpadReleased -= TouchpadReleased;
+        ce.TouchpadTouchStart -= TouchpadTouchStart;
+        ce.TouchpadTouchEnd -= TouchpadTouchEnd;
+        ce.TouchpadAxisChanged -= TouchpadAxisChanged;
+        ce.AliasPointerOn -= AliasPointerOn;
+        ce.AliasPointerOff -= AliasPointerOff;
+        ce.AliasPointerSet -= AliasPointerSet;
+        ce.AliasGrabOn -= AliasGrabOn;
+        ce.AliasGrabOff -= AliasGrabOff;
+        ce.AliasUseOn -= AliasUseOn;
+        ce.AliasUseOff -= AliasUseOff;
+        ce.AliasUIClickOn -= AliasUIClickOn;
+        ce.AliasUIClickOff -= AliasUIClickOff;
+        ce.AliasMenuOn -= AliasMenuOn;
+        ce.AliasMenuOff -= AliasMenuOff;
+    }
+}

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_ControllerEvents_UnityEvents.cs.meta
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_ControllerEvents_UnityEvents.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 6b7c8f5f1a0f45b4e99e3fbcbc5b94f3
+timeCreated: 1472935205
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_DestinationMarker_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_DestinationMarker_UnityEvents.cs
@@ -1,0 +1,64 @@
+﻿using UnityEngine;
+using UnityEngine.Events;
+using VRTK;
+
+[RequireComponent(typeof(VRTK_DestinationMarker))]
+public class VRTK_DestinationMarker_UnityEvents : MonoBehaviour
+{
+    private VRTK_DestinationMarker dm;
+
+    [System.Serializable]
+    public class UnityObjectEvent : UnityEvent<DestinationMarkerEventArgs> { };
+    public UnityObjectEvent OnDestinationMarkerEnter;
+    public UnityObjectEvent OnDestinationMarkerExit;
+    public UnityObjectEvent OnDestinationMarkerSet;
+
+    private void SetDestinationMarker()
+    {
+        if (dm == null)
+        {
+            dm = GetComponent<VRTK_DestinationMarker>();
+        }
+    }
+
+    private void OnEnable()
+    {
+        SetDestinationMarker();
+        if (dm == null)
+        {
+            Debug.LogError("The VRTK_DestinationMarker_UnityEvents script requires to be attached to a GameObject that contains a VRTK_DestinationMarker script");
+            return;
+        }
+
+        dm.DestinationMarkerEnter += DestinationMarkerEnter;
+        dm.DestinationMarkerExit += DestinationMarkerExit;
+        dm.DestinationMarkerSet += DestinationMarkerSet;
+    }
+
+    private void DestinationMarkerEnter(object o, DestinationMarkerEventArgs e)
+    {
+        OnDestinationMarkerEnter.Invoke(e);
+    }
+
+    private void DestinationMarkerExit(object o, DestinationMarkerEventArgs e)
+    {
+        OnDestinationMarkerExit.Invoke(e);
+    }
+
+    private void DestinationMarkerSet(object o, DestinationMarkerEventArgs e)
+    {
+        OnDestinationMarkerSet.Invoke(e);
+    }
+
+    private void OnDisable()
+    {
+        if (dm == null)
+        {
+            return;
+        }
+
+        dm.DestinationMarkerEnter -= DestinationMarkerEnter;
+        dm.DestinationMarkerExit -= DestinationMarkerExit;
+        dm.DestinationMarkerSet -= DestinationMarkerSet;
+    }
+}

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_DestinationMarker_UnityEvents.cs.meta
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_DestinationMarker_UnityEvents.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 01f558dc01554774f9e8d5ff8e5da938
+timeCreated: 1472908137
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_HeadsetCollision_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_HeadsetCollision_UnityEvents.cs
@@ -1,0 +1,56 @@
+﻿using UnityEngine;
+using UnityEngine.Events;
+using VRTK;
+
+[RequireComponent(typeof(VRTK_HeadsetCollision))]
+public class VRTK_HeadsetCollision_UnityEvents : MonoBehaviour
+{
+    private VRTK_HeadsetCollision hc;
+
+    [System.Serializable]
+    public class UnityObjectEvent : UnityEvent<HeadsetCollisionEventArgs> { };
+    public UnityObjectEvent OnHeadsetCollisionDetect;
+    public UnityObjectEvent OnHeadsetCollisionEnded;
+
+    private void SetHeadsetCollision()
+    {
+        if (hc == null)
+        {
+            hc = GetComponent<VRTK_HeadsetCollision>();
+        }
+    }
+
+    private void OnEnable()
+    {
+        SetHeadsetCollision();
+        if (hc == null)
+        {
+            Debug.LogError("The VRTK_HeadsetCollision_UnityEvents script requires to be attached to a GameObject that contains a VRTK_HeadsetCollision script");
+            return;
+        }
+
+        hc.HeadsetCollisionDetect += HeadsetCollisionDetect;
+        hc.HeadsetCollisionEnded += HeadsetCollisionEnded;
+    }
+
+    private void HeadsetCollisionDetect(object o, HeadsetCollisionEventArgs e)
+    {
+        OnHeadsetCollisionDetect.Invoke(e);
+    }
+
+    private void HeadsetCollisionEnded(object o, HeadsetCollisionEventArgs e)
+    {
+        OnHeadsetCollisionEnded.Invoke(e);
+    }
+
+    private void OnDisable()
+    {
+        if (hc == null)
+        {
+            return;
+        }
+
+        hc.HeadsetCollisionDetect -= HeadsetCollisionDetect;
+        hc.HeadsetCollisionEnded -= HeadsetCollisionEnded;
+    }
+}

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_HeadsetCollision_UnityEvents.cs.meta
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_HeadsetCollision_UnityEvents.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 180db21be63de364480f0cd4cfa620c8
+timeCreated: 1472927775
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_HeadsetFade_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_HeadsetFade_UnityEvents.cs
@@ -1,0 +1,72 @@
+﻿using UnityEngine;
+using UnityEngine.Events;
+using VRTK;
+
+[RequireComponent(typeof(VRTK_HeadsetFade))]
+public class VRTK_HeadsetFade_UnityEvents : MonoBehaviour
+{
+    private VRTK_HeadsetFade hf;
+
+    [System.Serializable]
+    public class UnityObjectEvent : UnityEvent<HeadsetFadeEventArgs> { };
+    public UnityObjectEvent OnHeadsetFadeStart;
+    public UnityObjectEvent OnHeadsetFadeComplete;
+    public UnityObjectEvent OnHeadsetUnfadeStart;
+    public UnityObjectEvent OnHeadsetUnfadeComplete;
+
+    private void SetHeadsetFade()
+    {
+        if (hf == null)
+        {
+            hf = GetComponent<VRTK_HeadsetFade>();
+        }
+    }
+
+    private void OnEnable()
+    {
+        SetHeadsetFade();
+        if (hf == null)
+        {
+            Debug.LogError("The VRTK_HeadsetFade_UnityEvents script requires to be attached to a GameObject that contains a VRTK_HeadsetFade script");
+            return;
+        }
+
+        hf.HeadsetFadeStart += HeadsetFadeStart;
+        hf.HeadsetFadeComplete += HeadsetFadeComplete;
+        hf.HeadsetUnfadeStart += HeadsetUnfadeStart;
+        hf.HeadsetUnfadeComplete += HeadsetUnfadeComplete;
+    }
+
+    private void HeadsetFadeStart(object o, HeadsetFadeEventArgs e)
+    {
+        OnHeadsetFadeStart.Invoke(e);
+    }
+
+    private void HeadsetFadeComplete(object o, HeadsetFadeEventArgs e)
+    {
+        OnHeadsetFadeComplete.Invoke(e);
+    }
+
+    private void HeadsetUnfadeStart(object o, HeadsetFadeEventArgs e)
+    {
+        OnHeadsetUnfadeStart.Invoke(e);
+    }
+
+    private void HeadsetUnfadeComplete(object o, HeadsetFadeEventArgs e)
+    {
+        OnHeadsetUnfadeComplete.Invoke(e);
+    }
+
+    private void OnDisable()
+    {
+        if (hf == null)
+        {
+            return;
+        }
+
+        hf.HeadsetFadeStart -= HeadsetFadeStart;
+        hf.HeadsetFadeComplete -= HeadsetFadeComplete;
+        hf.HeadsetUnfadeStart -= HeadsetUnfadeStart;
+        hf.HeadsetUnfadeComplete -= HeadsetUnfadeComplete;
+    }
+}

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_HeadsetFade_UnityEvents.cs.meta
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_HeadsetFade_UnityEvents.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 8906f57ecebad8e43bfb670c64a8009b
+timeCreated: 1472925939
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_InteractGrab_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_InteractGrab_UnityEvents.cs
@@ -1,0 +1,56 @@
+﻿using UnityEngine;
+using UnityEngine.Events;
+using VRTK;
+
+[RequireComponent(typeof(VRTK_InteractGrab))]
+public class VRTK_InteractGrab_UnityEvents : MonoBehaviour
+{
+    private VRTK_InteractGrab ig;
+
+    [System.Serializable]
+    public class UnityObjectEvent : UnityEvent<ObjectInteractEventArgs> { };
+    public UnityObjectEvent OnControllerGrabInteractableObject;
+    public UnityObjectEvent OnControllerUngrabInteractableObject;
+
+    private void SetInteractGrab()
+    {
+        if (ig == null)
+        {
+            ig = GetComponent<VRTK_InteractGrab>();
+        }
+    }
+
+    private void OnEnable()
+    {
+        SetInteractGrab();
+        if (ig == null)
+        {
+            Debug.LogError("The VRTK_InteractGrab_UnityEvents script requires to be attached to a GameObject that contains a VRTK_InteractGrab script");
+            return;
+        }
+
+        ig.ControllerGrabInteractableObject += ControllerGrabInteractableObject;
+        ig.ControllerUngrabInteractableObject += ControllerUngrabInteractableObject;
+    }
+
+    private void ControllerGrabInteractableObject(object o, ObjectInteractEventArgs e)
+    {
+        OnControllerGrabInteractableObject.Invoke(e);
+    }
+
+    private void ControllerUngrabInteractableObject(object o, ObjectInteractEventArgs e)
+    {
+        OnControllerUngrabInteractableObject.Invoke(e);
+    }
+
+    private void OnDisable()
+    {
+        if (ig == null)
+        {
+            return;
+        }
+
+        ig.ControllerGrabInteractableObject -= ControllerGrabInteractableObject;
+        ig.ControllerUngrabInteractableObject -= ControllerUngrabInteractableObject;
+    }
+}

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_InteractGrab_UnityEvents.cs.meta
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_InteractGrab_UnityEvents.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 8968b5d420eccb44b9ca55dd8b291b46
+timeCreated: 1472938325
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_InteractTouch_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_InteractTouch_UnityEvents.cs
@@ -1,0 +1,56 @@
+﻿using UnityEngine;
+using UnityEngine.Events;
+using VRTK;
+
+[RequireComponent(typeof(VRTK_InteractTouch))]
+public class VRTK_InteractTouch_UnityEvents : MonoBehaviour
+{
+    private VRTK_InteractTouch it;
+
+    [System.Serializable]
+    public class UnityObjectEvent : UnityEvent<ObjectInteractEventArgs> { };
+    public UnityObjectEvent OnControllerTouchInteractableObject;
+    public UnityObjectEvent OnControllerUntouchInteractableObject;
+
+    private void SetInteractTouch()
+    {
+        if (it == null)
+        {
+            it = GetComponent<VRTK_InteractTouch>();
+        }
+    }
+
+    private void OnEnable()
+    {
+        SetInteractTouch();
+        if (it == null)
+        {
+            Debug.LogError("The VRTK_InteractTouch_UnityEvents script requires to be attached to a GameObject that contains a VRTK_InteractTouch script");
+            return;
+        }
+
+        it.ControllerTouchInteractableObject += ControllerTouchInteractableObject;
+        it.ControllerUntouchInteractableObject += ControllerUntouchInteractableObject;
+    }
+
+    private void ControllerTouchInteractableObject(object o, ObjectInteractEventArgs e)
+    {
+        OnControllerTouchInteractableObject.Invoke(e);
+    }
+
+    private void ControllerUntouchInteractableObject(object o, ObjectInteractEventArgs e)
+    {
+        OnControllerUntouchInteractableObject.Invoke(e);
+    }
+
+    private void OnDisable()
+    {
+        if (it == null)
+        {
+            return;
+        }
+
+        it.ControllerTouchInteractableObject -= ControllerTouchInteractableObject;
+        it.ControllerUntouchInteractableObject -= ControllerUntouchInteractableObject;
+    }
+}

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_InteractTouch_UnityEvents.cs.meta
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_InteractTouch_UnityEvents.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 3e2e7c991ef4604498c54b06ede8b6fd
+timeCreated: 1472925174
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_InteractUse_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_InteractUse_UnityEvents.cs
@@ -1,0 +1,56 @@
+﻿using UnityEngine;
+using UnityEngine.Events;
+using VRTK;
+
+[RequireComponent(typeof(VRTK_InteractUse))]
+public class VRTK_InteractUse_UnityEvents : MonoBehaviour
+{
+    private VRTK_InteractUse iu;
+
+    [System.Serializable]
+    public class UnityObjectEvent : UnityEvent<ObjectInteractEventArgs> { };
+    public UnityObjectEvent OnControllerUseInteractableObject;
+    public UnityObjectEvent OnControllerUnuseInteractableObject;
+
+    private void SetInteractUse()
+    {
+        if (iu == null)
+        {
+            iu = GetComponent<VRTK_InteractUse>();
+        }
+    }
+
+    private void OnEnable()
+    {
+        SetInteractUse();
+        if (iu == null)
+        {
+            Debug.LogError("The VRTK_InteractUse_UnityEvents script requires to be attached to a GameObject that contains a VRTK_InteractUse script");
+            return;
+        }
+
+        iu.ControllerUseInteractableObject += ControllerUseInteractableObject;
+        iu.ControllerUnuseInteractableObject += ControllerUnuseInteractableObject;
+    }
+
+    private void ControllerUseInteractableObject(object o, ObjectInteractEventArgs e)
+    {
+        OnControllerUseInteractableObject.Invoke(e);
+    }
+
+    private void ControllerUnuseInteractableObject(object o, ObjectInteractEventArgs e)
+    {
+        OnControllerUnuseInteractableObject.Invoke(e);
+    }
+
+    private void OnDisable()
+    {
+        if (iu == null)
+        {
+            return;
+        }
+
+        iu.ControllerUseInteractableObject -= ControllerUseInteractableObject;
+        iu.ControllerUnuseInteractableObject -= ControllerUnuseInteractableObject;
+    }
+}

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_InteractUse_UnityEvents.cs.meta
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_InteractUse_UnityEvents.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: bc118d7b0ac84c248beb1cd5cb7cd2d8
+timeCreated: 1472938981
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_InteractableObject_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_InteractableObject_UnityEvents.cs
@@ -1,12 +1,10 @@
 ﻿using UnityEngine;
-using System.Collections;
 using UnityEngine.Events;
 using VRTK;
 
 [RequireComponent(typeof(VRTK_InteractableObject))]
 public class VRTK_InteractableObject_UnityEvents : MonoBehaviour
 {
-
     private VRTK_InteractableObject io;
 
     [System.Serializable]

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_PlayerClimb_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_PlayerClimb_UnityEvents.cs
@@ -1,0 +1,56 @@
+﻿using UnityEngine;
+using UnityEngine.Events;
+using VRTK;
+
+[RequireComponent(typeof(VRTK_PlayerClimb))]
+public class VRTK_PlayerClimb_UnityEvents : MonoBehaviour
+{
+    private VRTK_PlayerClimb pc;
+
+    [System.Serializable]
+    public class UnityObjectEvent : UnityEvent<PlayerClimbEventArgs> { };
+    public UnityObjectEvent OnPlayerClimbStarted;
+    public UnityObjectEvent OnPlayerClimbEnded;
+
+    private void SetPlayerClimb()
+    {
+        if (pc == null)
+        {
+            pc = GetComponent<VRTK_PlayerClimb>();
+        }
+    }
+
+    private void OnEnable()
+    {
+        SetPlayerClimb();
+        if (pc == null)
+        {
+            Debug.LogError("The VRTK_PlayerClimb_UnityEvents script requires to be attached to a GameObject that contains a VRTK_PlayerClimb script");
+            return;
+        }
+
+        pc.PlayerClimbStarted += PlayerClimbStarted;
+        pc.PlayerClimbEnded += PlayerClimbEnded;
+    }
+
+    private void PlayerClimbStarted(object o, PlayerClimbEventArgs e)
+    {
+        OnPlayerClimbStarted.Invoke(e);
+    }
+
+    private void PlayerClimbEnded(object o, PlayerClimbEventArgs e)
+    {
+        OnPlayerClimbEnded.Invoke(e);
+    }
+
+    private void OnDisable()
+    {
+        if (pc == null)
+        {
+            return;
+        }
+
+        pc.PlayerClimbStarted -= PlayerClimbStarted;
+        pc.PlayerClimbEnded -= PlayerClimbEnded;
+    }
+}

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_PlayerClimb_UnityEvents.cs.meta
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_PlayerClimb_UnityEvents.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 7c9a541ba27f72142a0a8f1163a65843
+timeCreated: 1472924940
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_PlayerPresence_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_PlayerPresence_UnityEvents.cs
@@ -1,0 +1,56 @@
+﻿using UnityEngine;
+using UnityEngine.Events;
+using VRTK;
+
+[RequireComponent(typeof(VRTK_PlayerPresence))]
+public class VRTK_PlayerPresence_UnityEvents : MonoBehaviour
+{
+    private VRTK_PlayerPresence pp;
+
+    [System.Serializable]
+    public class UnityObjectEvent : UnityEvent<PlayerPresenceEventArgs> { };
+    public UnityObjectEvent OnPresenceFallStarted;
+    public UnityObjectEvent OnPresenceFallEnded;
+
+    private void SetPlayerPresence()
+    {
+        if (pp == null)
+        {
+            pp = GetComponent<VRTK_PlayerPresence>();
+        }
+    }
+
+    private void OnEnable()
+    {
+        SetPlayerPresence();
+        if (pp == null)
+        {
+            Debug.LogError("The VRTK_PlayerPresence_UnityEvents script requires to be attached to a GameObject that contains a VRTK_PlayerPresence script");
+            return;
+        }
+
+        pp.PresenceFallStarted += PresenceFallStarted;
+        pp.PresenceFallEnded += PresenceFallEnded;
+    }
+
+    private void PresenceFallStarted(object o, PlayerPresenceEventArgs e)
+    {
+        OnPresenceFallStarted.Invoke(e);
+    }
+
+    private void PresenceFallEnded(object o, PlayerPresenceEventArgs e)
+    {
+        OnPresenceFallEnded.Invoke(e);
+    }
+
+    private void OnDisable()
+    {
+        if (pp == null)
+        {
+            return;
+        }
+
+        pp.PresenceFallStarted -= PresenceFallStarted;
+        pp.PresenceFallEnded -= PresenceFallEnded;
+    }
+}

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_PlayerPresence_UnityEvents.cs.meta
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_PlayerPresence_UnityEvents.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: bd32e3e002f7ee84989aa4ac59996243
+timeCreated: 1472924405
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_UIPointer_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_UIPointer_UnityEvents.cs
@@ -1,0 +1,55 @@
+﻿using UnityEngine;
+using UnityEngine.Events;
+using VRTK;
+
+[RequireComponent(typeof(VRTK_UIPointer))]
+public class VRTK_UIPointer_UnityEvents : MonoBehaviour
+{
+    private VRTK_UIPointer uip;
+
+    [System.Serializable]
+    public class UnityObjectEvent : UnityEvent<UIPointerEventArgs> { };
+    public UnityObjectEvent OnUIPointerElementEnter;
+    public UnityObjectEvent OnUIPointerElementExit;
+
+    private void SetUIPointer()
+    {
+        if (uip == null)
+        {
+            uip = GetComponent<VRTK_UIPointer>();
+        }
+    }
+
+    private void OnEnable()
+    {
+        SetUIPointer();
+        if (uip == null)
+        {
+            Debug.LogError("The VRTK_UIPointer_UnityEvents script requires to be attached to a GameObject that contains a VRTK_UIPointer script");
+            return;
+        }
+        uip.UIPointerElementEnter += UIPointerElementEnter;
+        uip.UIPointerElementExit += UIPointerElementExit;
+    }
+
+    private void UIPointerElementEnter(object o, UIPointerEventArgs e)
+    {
+        OnUIPointerElementEnter.Invoke(e);
+    }
+
+    private void UIPointerElementExit(object o, UIPointerEventArgs e)
+    {
+        OnUIPointerElementExit.Invoke(e);
+    }
+
+    private void OnDisable()
+    {
+        if (uip == null)
+        {
+            return;
+        }
+
+        uip.UIPointerElementEnter -= UIPointerElementEnter;
+        uip.UIPointerElementExit -= UIPointerElementExit;
+    }
+}

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_UIPointer_UnityEvents.cs.meta
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_UIPointer_UnityEvents.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 90f6c0da1e5684e4c8c03acfadf2f77c
+timeCreated: 1472922699
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -285,6 +285,40 @@ The script also has a public boolean pressed state for the buttons to allow the 
   * `AliasUIClickOn` - Emitted when the UI click alias button is pressed.
   * `AliasUIClickOff` - Emitted when the UI click alias button is released.
 
+### Unity Events
+
+Adding the `VRTK_ControllerEvents_UnityEvents` component to `VRTK_ControllerEvents` object allows access to `UnityEvents` that will react identically to the Class Events.
+
+  * `OnTriggerPressed` - Emits the TriggerPressed class event.
+  * `OnTriggerReleased` - Emits the TriggerReleased class event.
+  * `OnTriggerTouchStart` - Emits the TriggerTouchStart class event.
+  * `OnTriggerTouchEnd` - Emits the TriggerTouchEnd class event.
+  * `OnTriggerHairlineStart` - Emits the TriggerHairlineStart class event.
+  * `OnTriggerHairlineEnd` - Emits the TriggerHairlineEnd class event.
+  * `OnTriggerClicked` - Emits the TriggerClicked class event.
+  * `OnTriggerUnclicked` - Emits the TriggerUnclicked class event.
+  * `OnTriggerAxisChanged` - Emits the TriggerAxisChanged class event.
+  * `OnApplicationMenuPressed` - Emits the ApplicationMenuPressed class event.
+  * `OnApplicationMenuReleased` - Emits the ApplicationMenuReleased class event.
+  * `OnGripPressed` - Emits the GripPressed class event.
+  * `OnGripReleased` - Emits the GripReleased class event.
+  * `OnTouchpadPressed` - Emits the TouchpadPressed class event.
+  * `OnTouchpadReleased` - Emits the TouchpadReleased class event.
+  * `OnTouchpadTouchStart` - Emits the TouchpadTouchStart class event.
+  * `OnTouchpadTouchEnd` - Emits the TouchpadTouchEnd class event.
+  * `OnTouchpadAxisChanged` - Emits the TouchpadAxisChanged class event.
+  * `OnAliasPointerOn` - Emits the AliasPointerOn class event.
+  * `OnAliasPointerOff` - Emits the AliasPointerOff class event.
+  * `OnAliasPointerSet` - Emits the AliasPointerSet class event.
+  * `OnAliasGrabOn` - Emits the AliasGrabOn class event.
+  * `OnAliasGrabOff` - Emits the AliasGrabOff class event.
+  * `OnAliasUseOn` - Emits the AliasUseOn class event.
+  * `OnAliasUseOff` - Emits the AliasUseOff class event.
+  * `OnAliasMenuOn` - Emits the AliasMenuOn class event.
+  * `OnAliasMenuOff` - Emits the AliasMenuOff class event.
+  * `OnAliasUIClickOn` - Emits the AliasUIClickOn class event.
+  * `OnAliasUIClickOff` - Emits the AliasUIClickOff class event.
+
 #### Event Payload
 
   * `uint controllerIndex` - The index of the controller that was used.
@@ -792,6 +826,13 @@ The UI pointer is activated via the `Pointer` alias on the `Controller Events` a
   * `UIPointerElementEnter` - Emitted when the UI Pointer is colliding with a valid UI element.
   * `UIPointerElementExit` - Emitted when the UI Pointer is no longer colliding with any valid UI elements.
 
+### Unity Events
+
+Adding the `VRTK_UIPointer_UnityEvents` component to `VRTK_UIPointer` object allows access to `UnityEvents` that will react identically to the Class Events.
+
+  * `OnUIPointerElementEnter` - Emits the UIPointerElementEnter class event.
+  * `OnUIPointerElementExit` - Emits the UIPointerElementExit class event.
+
 #### Event Payload
 
   * `uint controllerIndex` - The index of the controller that was used.
@@ -859,6 +900,13 @@ The Basic Teleport script is attached to the `[CameraRig]` prefab and requires a
 
   * `Teleporting` - Emitted when the teleport process has begun.
   * `Teleported` - Emitted when the teleport process has successfully completed.
+
+### Unity Events
+
+Adding the `VRTK_BasicTeleport_UnityEvents` component to `VRTK_BasicTeleport` object allows access to `UnityEvents` that will react identically to the Class Events.
+
+  * `OnTeleporting` - Emits the Teleporting class event.
+  * `OnTeleported` - Emits the Teleported class event.
 
 #### Event Payload
 
@@ -935,6 +983,13 @@ If the headset is colliding then the teleport action is also disabled to prevent
   * `HeadsetCollisionDetect` - Emitted when the user's headset collides with another game object.
   * `HeadsetCollisionEnded` - Emitted when the user's headset stops colliding with a game object.
 
+### Unity Events
+
+Adding the `VRTK_HeadsetCollision_UnityEvents` component to `VRTK_HeadsetCollision` object allows access to `UnityEvents` that will react identically to the Class Events.
+
+  * `OnHeadsetCollisionDetect` - Emits the HeadsetCollisionDetect class event.
+  * `OnHeadsetCollisionEnded` - Emits the HeadsetCollisionEnded class event.
+
 #### Event Payload
 
   * `Collider collider` - The Collider of the game object the headset has collided with.
@@ -975,6 +1030,15 @@ The purpose of the Headset Fade is to change the colour of the headset view to a
   * `HeadsetFadeComplete` - Emitted when the user's headset has completed the fade and is now fully at the given colour.
   * `HeadsetUnfadeStart` - Emitted when the user's headset begins to unfade back to a transparent colour.
   * `HeadsetUnfadeComplete` - Emitted when the user's headset has completed unfading and is now fully transparent again.
+
+### Unity Events
+
+Adding the `VRTK_HeadsetFade_UnityEvents` component to `VRTK_HeadsetFade` object allows access to `UnityEvents` that will react identically to the Class Events.
+
+  * `OnHeadsetFadeStart` - Emits the HeadsetFadeStart class event.
+  * `OnHeadsetFadeComplete` - Emits the HeadsetFadeComplete class event.
+  * `OnHeadsetUnfadeStart` - Emits the HeadsetUnfadeStart class event.
+  * `OnHeadsetUnfadeComplete` - Emits the HeadsetUnfadeComplete class event.
 
 #### Event Payload
 
@@ -1075,6 +1139,13 @@ The concept that the VR user has a physical in game presence which is accomplish
 
   * `PresenceFallStarted` - Emitted when a gravity based fall has started
   * `PresenceFallEnded` - Emitted when a gravity based fall has ended
+
+### Unity Events
+
+Adding the `VRTK_PlayerPresence_UnityEvents` component to `VRTK_PlayerPresence` object allows access to `UnityEvents` that will react identically to the Class Events.
+
+  * `OnPresenceFallStarted` - Emits the PresenceFallStarted class event.
+  * `OnPresenceFallEnded` - Emits the PresenceFallEnded class event.
 
 #### Event Payload
 
@@ -1271,14 +1342,14 @@ The basis of this script is to provide a simple mechanism for identifying object
 
 ### Unity Events
 
-Adding the `VRTK_InteractableObject_UnityEvents` component to an Interactable Object allows access to `UnityEvents` that will react identically to the Class Events.
+Adding the `VRTK_InteractableObject_UnityEvents` component to `VRTK_InteractableObject` object allows access to `UnityEvents` that will react identically to the Class Events.
 
-  * `OnTouch` - Emitted when another object touches the current object.
-  * `OnUntouch` - Emitted when the other object stops touching the current object.
-  * `OnGrab` - Emitted when another object grabs the current object (e.g. a controller).
-  * `OnUngrab` - Emitted when the other object stops grabbing the current object.
-  * `OnUse` - Emitted when another object uses the current object (e.g. a controller).
-  * `OnUnuse` - Emitted when the other object stops using the current object.
+  * `OnTouch` - Emits the InteractableObjectTouched class event.
+  * `OnUntouch` - Emits the InteractableObjectUntouched class event.
+  * `OnGrab` - Emits the InteractableObjectGrabbed class event.
+  * `OnUngrab` - Emits the InteractableObjectUngrabbed class event.
+  * `OnUse` - Emits the InteractableObjectUsed class event.
+  * `OnUnuse` - Emits the InteractableObjectUnused class event.
 
 #### Event Payload
 
@@ -1604,6 +1675,13 @@ The Interact Touch script is attached to a Controller object within the `[Camera
   * `ControllerTouchInteractableObject` - Emitted when a valid object is touched
   * `ControllerUntouchInteractableObject` - Emitted when a valid object is no longer being touched
 
+### Unity Events
+
+Adding the `VRTK_InteractTouch_UnityEvents` component to `VRTK_InteractTouch` object allows access to `UnityEvents` that will react identically to the Class Events.
+
+  * `OnControllerTouchInteractableObject` - Emits the ControllerTouchInteractableObject class event.
+  * `OnControllerUntouchInteractableObject` - Emits the ControllerUntouchInteractableObject class event.
+
 #### Event Payload
 
   * `uint controllerIndex` -  The index of the controller doing the interaction
@@ -1724,6 +1802,13 @@ The interactable objects require a collider to activate the trigger and a rigidb
   * `ControllerGrabInteractableObject` - Emitted when a valid object is grabbed.
   * `ControllerUngrabInteractableObject` - Emitted when a valid object is released from being grabbed.
 
+### Unity Events
+
+Adding the `VRTK_InteractGrab_UnityEvents` component to `VRTK_InteractGrab` object allows access to `UnityEvents` that will react identically to the Class Events.
+
+  * `OnControllerGrabInteractableObject` - Emits the ControllerGrabInteractableObject class event.
+  * `OnControllerUngrabInteractableObject` - Emits the ControllerUngrabInteractableObject class event.
+
 #### Event Payload
 
   * `uint controllerIndex` - The index of the controller doing the interaction.
@@ -1795,6 +1880,13 @@ If a valid interactable object is usable then pressing the set `Use` button on t
 
   * `ControllerUseInteractableObject` - Emitted when a valid object starts being used.
   * `ControllerUnuseInteractableObject` - Emitted when a valid object stops being used.
+
+### Unity Events
+
+Adding the `VRTK_InteractUse_UnityEvents` component to `VRTK_InteractUse` object allows access to `UnityEvents` that will react identically to the Class Events.
+
+  * `OnControllerUseInteractableObject` - Emits the ControllerUseInteractableObject class event.
+  * `OnControllerUnuseInteractableObject` - Emits the ControllerUnuseInteractableObject class event.
 
 #### Event Payload
 
@@ -1896,6 +1988,13 @@ This class allows player movement based on grabbing of `VRTK_InteractableObject`
 
   * `PlayerClimbStarted` - Emitted when player climbing has started.
   * `PlayerClimbEnded` - Emitted when player climbing has ended.
+
+### Unity Events
+
+Adding the `VRTK_PlayerClimb_UnityEvents` component to `VRTK_PlayerClimb` object allows access to `UnityEvents` that will react identically to the Class Events.
+
+  * `OnPlayerClimbStarted` - Emits the PlayerClimbStarted class event.
+  * `OnPlayerClimbEnded` - Emits the PlayerClimbEnded class event.
 
 #### Event Payload
 
@@ -2222,6 +2321,14 @@ It is utilised by the `VRTK_WorldPointer` for dealing with pointer events when t
   * `DestinationMarkerExit` - Emitted when the collision with the other game object finishes.
   * `DestinationMarkerSet` - Emitted when the destination marker is active in the scene to determine the last destination position (useful for selecting and teleporting).
 
+### Unity Events
+
+Adding the `VRTK_DestinationMarker_UnityEvents` component to `VRTK_DestinationMarker` object allows access to `UnityEvents` that will react identically to the Class Events.
+
+  * `OnDestinationMarkerEnter` - Emits the DestinationMarkerEnter class event.
+  * `OnDestinationMarkerExit` - Emits the DestinationMarkerExit class event.
+  * `OnDestinationMarkerSet` - Emits the DestinationMarkerSet class event.
+
 #### Event Payload
 
   * `float distance` - The distance between the origin and the collided destination.
@@ -2268,6 +2375,7 @@ The SetHeadsetPositionCompensation method determines whether the offset position
 ---
 
 ## VRTK_WorldPointer
+  > extends [VRTK_DestinationMarker](#vrtk_destinationmarker)
 
 ### Overview
 


### PR DESCRIPTION
The toolkit uses C# delegates to raise events, however, Unity Events
provide a nice inspector interface (but come at a performance cost) so
Unity Event helper scripts have been added that can be used to extend
the relevant script that is using a C# delegate to provide the benefit
of Unity Events but optionally to remove the requirement of the
performance overhead.