### PR TITLE
feat(Teleport): extract teleport disable on headset collision - resolves #514

### DIFF
--- a/Assets/VRTK/Scripts/VRTK_BasicTeleport.cs
+++ b/Assets/VRTK/Scripts/VRTK_BasicTeleport.cs
@@ -59,6 +59,11 @@ namespace VRTK
             }
         }
 
+        public void ToggleTeleportEnabled(bool state)
+        {
+            enableTeleport = state;
+        }
+
         protected virtual void Awake()
         {
             Utilities.SetPlayerObject(gameObject, VRTK_PlayerObject.ObjectTypes.CameraRig);
@@ -76,7 +81,6 @@ namespace VRTK
         protected virtual void OnDisable()
         {
             InitDestinationMarkerListeners(false);
-            InitHeadsetCollisionListener(false);
             VRTK_ObjectCache.registeredTeleporters.Remove(this);
         }
 
@@ -183,7 +187,6 @@ namespace VRTK
         {
             yield return new WaitForEndOfFrame();
             InitDestinationMarkerListeners(true);
-            InitHeadsetCollisionListener(true);
         }
 
         private void InitDestinationMarkerListeners(bool state)
@@ -199,34 +202,6 @@ namespace VRTK
                     InitDestinationSetListener(destinationMarker.gameObject, state);
                 }
             }
-        }
-
-        private void InitHeadsetCollisionListener(bool state)
-        {
-            var headset = VRTK_ObjectCache.registeredHeadsetCollider;
-            if (headset)
-            {
-                if (state)
-                {
-                    headset.HeadsetCollisionDetect += new HeadsetCollisionEventHandler(DisableTeleport);
-                    headset.HeadsetCollisionEnded += new HeadsetCollisionEventHandler(EnableTeleport);
-                }
-                else
-                {
-                    headset.HeadsetCollisionDetect -= new HeadsetCollisionEventHandler(DisableTeleport);
-                    headset.HeadsetCollisionEnded -= new HeadsetCollisionEventHandler(EnableTeleport);
-                }
-            }
-        }
-
-        private void DisableTeleport(object sender, HeadsetCollisionEventArgs e)
-        {
-            enableTeleport = false;
-        }
-
-        private void EnableTeleport(object sender, HeadsetCollisionEventArgs e)
-        {
-            enableTeleport = true;
         }
     }
 }

--- a/Assets/VRTK/Scripts/VRTK_TeleportDisableOnHeadsetCollision.cs
+++ b/Assets/VRTK/Scripts/VRTK_TeleportDisableOnHeadsetCollision.cs
@@ -1,0 +1,57 @@
+﻿namespace VRTK
+{
+    using UnityEngine;
+    using System.Collections;
+
+    public class VRTK_TeleportDisableOnHeadsetCollision : MonoBehaviour
+    {
+        private VRTK_BasicTeleport basicTeleport;
+        private VRTK_HeadsetCollision headset;
+
+        private void OnEnable()
+        {
+            basicTeleport = GetComponent<VRTK_BasicTeleport>();
+            StartCoroutine(EnableAtEndOfFrame());
+        }
+
+        private IEnumerator EnableAtEndOfFrame()
+        {
+            if (basicTeleport == null)
+            {
+                yield break;
+            }
+            yield return new WaitForEndOfFrame();
+
+            headset = VRTK_ObjectCache.registeredHeadsetCollider;
+            if (headset)
+            {
+                headset.HeadsetCollisionDetect += new HeadsetCollisionEventHandler(DisableTeleport);
+                headset.HeadsetCollisionEnded += new HeadsetCollisionEventHandler(EnableTeleport);
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (basicTeleport == null)
+            {
+                return;
+            }
+
+            if (headset)
+            {
+                headset.HeadsetCollisionDetect -= new HeadsetCollisionEventHandler(DisableTeleport);
+                headset.HeadsetCollisionEnded -= new HeadsetCollisionEventHandler(EnableTeleport);
+            }
+        }
+
+        private void DisableTeleport(object sender, HeadsetCollisionEventArgs e)
+        {
+            basicTeleport.ToggleTeleportEnabled(false);
+        }
+
+        private void EnableTeleport(object sender, HeadsetCollisionEventArgs e)
+        {
+            basicTeleport.ToggleTeleportEnabled(true);
+        }
+    }
+}

--- a/Assets/VRTK/Scripts/VRTK_TeleportDisableOnHeadsetCollision.cs.meta
+++ b/Assets/VRTK/Scripts/VRTK_TeleportDisableOnHeadsetCollision.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 3312e673b929b694d910e18143c4eb20
+timeCreated: 1473021823
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -199,6 +199,7 @@ This directory contains all of the toolkit scripts that add VR functionality to 
  * [VRTK_HeadsetCollision](#headset-collision-vrtk_headsetcollision)
  * [VRTK_HeadsetFade](#headset-fade-vrtk_headsetfade)
  * [VRTK_HeadsetCollisionFade](#headset-collision-fade-vrtk_headsetcollisionfade)
+ * [VRTK_TeleportDisableOnHeadsetCollision](#teleport-disable-on-headset-collision)
  * [VRTK_PlayerPresence](#player-presence-vrtk_playerpresence)
  * [VRTK_TouchpadWalking](#touchpad-movement-vrtk_touchpadwalking)
  * [VRTK_RoomExtender](#play-space-extension-vrtk_roomextender)
@@ -925,6 +926,17 @@ Adding the `VRTK_BasicTeleport_UnityEvents` component to `VRTK_BasicTeleport` ob
 
 The InitDestinationSetListener method is used to register the teleport script to listen to events from the given game object that is used to generate destination markers. Any destination set event emitted by a registered game object will initiate the teleport to the given destination location.
 
+#### ToggleTeleportEnabled/1
+
+  > `public void ToggleTeleportEnabled(bool state)`
+
+  * Parameters
+   * `bool state` - Toggles whether the teleporter is enabled or disabled.
+  * Returns
+   * _none_
+
+The ToggleTeleportEnabled method is used to determine whether the teleporter will initiate a teleport on a destination set event, if the state is true then the teleporter will work as normal, if the state is false then the teleporter will not be operational.
+
 ### Example
 
 `VRTK/Examples/004_CameraRig_BasicTeleport` uses the `VRTK_SimplePointer` script on the Controllers to initiate a laser pointer by pressing the `Touchpad` on the controller and when the laser pointer is deactivated (release the `Touchpad`) then the user is teleported to the location of the laser pointer tip as this is where the pointer destination marker position is set to.
@@ -1119,6 +1131,14 @@ The Headset Collision Fade uses a composition of the Headset Collision and Heads
 ### Example
 
 `VRTK/Examples/011_Camera_HeadSetCollisionFading` has collidable walls around the play area and if the user puts their head into any of the walls then the headset will fade to black.
+
+---
+
+## Teleport Disable On Headset Collision (VRTK_TeleportDisableOnHeadsetCollision)
+
+### Overview
+
+The purpose of the Teleport Disable On Headset Collision script is to detect when the headset is colliding with a valid object and prevent teleportation from working. This is to ensure that if a user is clipping their head into a wall then they cannot teleport to an area beyond the wall.
 
 ---
 


### PR DESCRIPTION
The ability to disable the teleport on headset collision has now been
extracted into it's own script to decouple the feature and also to
make it optional in case it's valid for teleporting to happen on
headset collision.