### PR TITLE
fix(UIPointer): prevent central button flickering on hover - resolves #527

### DIFF
--- a/Assets/VRTK/Scripts/Helper/VRTK_UIGraphicRaycaster.cs
+++ b/Assets/VRTK/Scripts/Helper/VRTK_UIGraphicRaycaster.cs
@@ -20,6 +20,7 @@
 
         private Canvas m_Canvas;
         private Vector2 lastKnownPosition;
+        private const float UI_CONTROL_OFFSET = 0.00001f;
 
         [NonSerialized]
         private List<VRGraphic> m_RaycastResults = new List<VRGraphic>();
@@ -123,7 +124,7 @@
                     continue;
                 }
 
-                if (distance > hitDistance)
+                if ((distance - UI_CONTROL_OFFSET) > hitDistance)
                 {
                     continue;
                 }


### PR DESCRIPTION
The `UI_CONTROL_OFFSET` const was previously removed as it was thought
it was no longer required. However, the offset does provide a mechanism
for preventing a discrepancy in hit distance that will cause a UI
element if centrally placed in the canvas to constantly hover enter and
immediately hover exit repeatidly. This causes the button flicker as
the button is constantly being hovered over and then out.

The fix is to put the `UI_CONTROL_OFFSET` back in but just set the
offset at a very low value so it stops the ui raycast at a blocking
object but will not trigger the discrepancy with the button flickering.