### PR TITLE
fix(Interaction): ensure undroppable objects cannot be dropped - resolves #535

### DIFF
--- a/Assets/VRTK/Scripts/VRTK_InteractableObject.cs
+++ b/Assets/VRTK/Scripts/VRTK_InteractableObject.cs
@@ -766,7 +766,7 @@ namespace VRTK
 
         private void CheckBreakDistance()
         {
-            if (trackPoint)
+            if (trackPoint && isDroppable)
             {
                 float distance = Vector3.Distance(trackPoint.position, originalControllerAttachPoint.position);
                 if (distance > (detachThreshold / 1000))


### PR DESCRIPTION
If the Interactable Object is set as `isDroppable = false` then it
should not be able to drop the object by the joint breaking or
the object/controller distance being too far. It should also not
drop if the controller is disabled but it will drop if the
Interactable Object is disabled.

The way the prevent drop works on controller disable is by storing
a reference to the grabbed object then auto grabbing it again
when the controller is re-enabled.