### PR TITLE
perf(Controller): cache tracked objects for controllers

### DIFF
--- a/Assets/VRTK/SDK/SteamVR/VRTK_SDK_Bridge.cs
+++ b/Assets/VRTK/SDK/SteamVR/VRTK_SDK_Bridge.cs
@@ -10,8 +10,27 @@
         private static Transform cachedHeadsetCamera;
         private static Transform cachedPlayArea;
 
+        public static GameObject GetTrackedObject(GameObject obj, out uint index)
+        {
+            var trackedObject = obj.GetComponent<SteamVR_TrackedObject>();
+            index = 0;
+            if (trackedObject)
+            {
+                index = (uint)trackedObject.index;
+                return trackedObject.gameObject;
+            }
+            return null;
+        }
+
         public static GameObject GetTrackedObjectByIndex(uint index)
         {
+            //attempt to get from cache first
+            if (VRTK_ObjectCache.trackedControllers.ContainsKey(index))
+            {
+                return VRTK_ObjectCache.trackedControllers[index];
+            }
+
+            //if not found in cache then brute force check
             foreach (SteamVR_TrackedObject trackedObject in FindObjectsOfType<SteamVR_TrackedObject>())
             {
                 if ((uint)trackedObject.index == index)
@@ -19,17 +38,15 @@
                     return trackedObject.gameObject;
                 }
             }
+
             return null;
         }
 
         public static uint GetIndexOfTrackedObject(GameObject trackedObject)
         {
-            var obj = trackedObject.GetComponent<SteamVR_TrackedObject>();
-            if (obj)
-            {
-                return (uint)obj.index;
-            }
-            return 0;
+            uint index = 0;
+            GetTrackedObject(trackedObject, out index);
+            return index;
         }
 
         public static Transform GetTrackedObjectOrigin(GameObject obj)

--- a/Assets/VRTK/Scripts/Helper/VRTK_ObjectCache.cs
+++ b/Assets/VRTK/Scripts/Helper/VRTK_ObjectCache.cs
@@ -8,5 +8,6 @@
         public static List<VRTK_BasicTeleport> registeredTeleporters = new List<VRTK_BasicTeleport>();
         public static List<VRTK_DestinationMarker> registeredDestinationMarkers = new List<VRTK_DestinationMarker>();
         public static VRTK_HeadsetCollision registeredHeadsetCollider = null;
+        public static Dictionary<uint, GameObject> trackedControllers = new Dictionary<uint, GameObject>();
     }
 }

--- a/Assets/VRTK/Scripts/VRTK_DeviceFinder.cs
+++ b/Assets/VRTK/Scripts/VRTK_DeviceFinder.cs
@@ -75,6 +75,17 @@ namespace VRTK
         }
 
         /// <summary>
+        /// The TrackedObjectOfGameObject method is used to find the tracked object associated with the given game object and it can also return the index of the tracked object.
+        /// </summary>
+        /// <param name="obj">The game object to check for the presence of a tracked object on.</param>
+        /// <param name="index">The variable to store the tracked object's index if one is found. It returns 0 if no index is found.</param>
+        /// <returns>The GameObject of the tracked object.</returns>
+        public static GameObject TrackedObjectOfGameObject(GameObject obj, out uint index)
+        {
+            return VRTK_SDK_Bridge.GetTrackedObject(obj, out index);
+        }
+
+        /// <summary>
         /// The DeviceTransform method returns the transform for a given Devices enum.
         /// </summary>
         /// <param name="device">The Devices enum to get the transform for.</param>

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -886,6 +886,18 @@ The TrackedObjectByIndex method is used to find the GameObject of a tracked obje
 
 The TrackedObjectOrigin method is used to find the tracked object's origin.
 
+#### TrackedObjectOfGameObject/2
+
+  > `public static GameObject TrackedObjectOfGameObject(GameObject obj, out uint index)`
+
+  * Parameters
+   * `GameObject obj` - The game object to check for the presence of a tracked object on.
+   * `out uint index` - The variable to store the tracked object's index if one is found. It returns 0 if no index is found.
+  * Returns
+   * `GameObject` - The GameObject of the tracked object.
+
+The TrackedObjectOfGameObject method is used to find the tracked object associated with the given game object and it can also return the index of the tracked object.
+
 #### DeviceTransform/1
 
   > `public static Transform DeviceTransform(Devices device)`


### PR DESCRIPTION
The Controller Events script will now attempt to cache the tracked
object associated with the controller and the SDK Bridge will
attempt to get a tracked object by index from the cache before
attempting to do an expensive `FindObjectOfType` call.