### PR TITLE
chore(Controller): decouple model paths into sdk bridge

### DIFF
--- a/Assets/VRTK/SDK/SteamVR/VRTK_SDK_Bridge.cs
+++ b/Assets/VRTK/SDK/SteamVR/VRTK_SDK_Bridge.cs
@@ -10,6 +10,15 @@
         private static Transform cachedHeadsetCamera;
         private static Transform cachedPlayArea;
 
+        public static string defaultAttachPointPath = "Model/tip/attach";
+        public static string defaultTriggerModelPath = "Model/trigger";
+        public static string defaultGripLeftModelPath = "Model/lgrip";
+        public static string defaultGripRightModelPath = "Model/rgrip";
+        public static string defaultTouchpadModelPath = "Model/trackpad";
+        public static string defaultApplicationMenuModelPath = "Model/button";
+        public static string defaultSystemModelPath = "Model/sys_button";
+        public static string defaultBodyModelPath = "Model/body";
+
         public static GameObject GetTrackedObject(GameObject obj, out uint index)
         {
             var trackedObject = obj.GetComponent<SteamVR_TrackedObject>();

--- a/Assets/VRTK/Scripts/VRTK_ControllerActions.cs
+++ b/Assets/VRTK/Scripts/VRTK_ControllerActions.cs
@@ -330,7 +330,7 @@ namespace VRTK
 
         private Transform GetElementTransform(string path)
         {
-            if (!cachedElements.ContainsKey(path))
+            if (!cachedElements.ContainsKey(path) || cachedElements[path] == null)
             {
                 cachedElements[path] = transform.Find(path);
             }

--- a/Assets/VRTK/Scripts/VRTK_ControllerActions.cs
+++ b/Assets/VRTK/Scripts/VRTK_ControllerActions.cs
@@ -189,7 +189,7 @@ namespace VRTK
             {
                 return;
             }
-            ToggleHighlightAlias(state, "Model/trigger", highlight, duration);
+            ToggleHighlightAlias(state, VRTK_SDK_Bridge.defaultTriggerModelPath, highlight, duration);
         }
 
         /// <summary>
@@ -204,8 +204,8 @@ namespace VRTK
             {
                 return;
             }
-            ToggleHighlightAlias(state, "Model/lgrip", highlight, duration);
-            ToggleHighlightAlias(state, "Model/rgrip", highlight, duration);
+            ToggleHighlightAlias(state, VRTK_SDK_Bridge.defaultGripLeftModelPath, highlight, duration);
+            ToggleHighlightAlias(state, VRTK_SDK_Bridge.defaultGripRightModelPath, highlight, duration);
         }
 
         /// <summary>
@@ -220,7 +220,7 @@ namespace VRTK
             {
                 return;
             }
-            ToggleHighlightAlias(state, "Model/trackpad", highlight, duration);
+            ToggleHighlightAlias(state, VRTK_SDK_Bridge.defaultTouchpadModelPath, highlight, duration);
         }
 
         /// <summary>
@@ -235,7 +235,7 @@ namespace VRTK
             {
                 return;
             }
-            ToggleHighlightAlias(state, "Model/button", highlight, duration);
+            ToggleHighlightAlias(state, VRTK_SDK_Bridge.defaultApplicationMenuModelPath, highlight, duration);
         }
 
         /// <summary>
@@ -251,8 +251,8 @@ namespace VRTK
             ToggleHighlightGrip(state, highlight, duration);
             ToggleHighlightTouchpad(state, highlight, duration);
             ToggleHighlightApplicationMenu(state, highlight, duration);
-            ToggleHighlightAlias(state, "Model/sys_button", highlight, duration);
-            ToggleHighlightAlias(state, "Model/body", highlight, duration);
+            ToggleHighlightAlias(state, VRTK_SDK_Bridge.defaultSystemModelPath, highlight, duration);
+            ToggleHighlightAlias(state, VRTK_SDK_Bridge.defaultBodyModelPath, highlight, duration);
         }
 
         /// <summary>

--- a/Assets/VRTK/Scripts/VRTK_InteractGrab.cs
+++ b/Assets/VRTK/Scripts/VRTK_InteractGrab.cs
@@ -169,7 +169,7 @@ namespace VRTK
             if (controllerAttachPoint == null)
             {
                 //attempt to find the attach point on the controller
-                var defaultAttachPoint = transform.Find("Model/tip/attach");
+                var defaultAttachPoint = transform.Find(VRTK_SDK_Bridge.defaultAttachPointPath);
                 if (defaultAttachPoint != null)
                 {
                     controllerAttachPoint = defaultAttachPoint.GetComponent<Rigidbody>();


### PR DESCRIPTION
The string paths to the model parts are now within the SDK Bridge
script as they will most likely differ for different SDK libraries.