### PR TITLE
feat(PolicyList): add ability to have multiple tag/script ignore checks

### DIFF
--- a/Assets/VRTK/Scripts/Abstractions/VRTK_DestinationMarker.cs
+++ b/Assets/VRTK/Scripts/Abstractions/VRTK_DestinationMarker.cs
@@ -52,6 +52,7 @@ namespace VRTK
         public event DestinationMarkerEventHandler DestinationMarkerSet;
 
         protected string invalidTargetWithTagOrClass;
+        protected VRTK_TagOrScriptPolicyList invalidTagOrScriptListPolicy;
         protected float navMeshCheckDistance;
         protected bool headsetPositionCompensation;
 
@@ -80,12 +81,15 @@ namespace VRTK
         }
 
         /// <summary>
-        /// The SetInvalidTarget method is used to set objects that contain the given tag or class matching the name as invalid destination targets.
+        /// The SetInvalidTarget method is used to set objects that contain the given tag or class matching the name as invalid destination targets. It can also accept a VRTK_TagOrScriptPolicyList for a more custom level of policy management.
         /// </summary>
         /// <param name="name">The name of the tag or class that is the invalid target.</param>
-        public virtual void SetInvalidTarget(string name)
+        /// <param name="list">The Tag Or Script list policy to check the set operation on.</param>
+        public virtual void SetInvalidTarget(string name, VRTK_TagOrScriptPolicyList list = null)
         {
             invalidTargetWithTagOrClass = name;
+            invalidTagOrScriptListPolicy = list;
+
         }
 
         /// <summary>

--- a/Assets/VRTK/Scripts/Abstractions/VRTK_WorldPointer.cs
+++ b/Assets/VRTK/Scripts/Abstractions/VRTK_WorldPointer.cs
@@ -42,6 +42,8 @@ namespace VRTK
         public bool handlePlayAreaCursorCollisions = false;
         [Tooltip("A string that specifies an object Tag or the name of a Script attached to an object and notifies the play area cursor to ignore collisions with the object.")]
         public string ignoreTargetWithTagOrClass;
+        [Tooltip("A specified VRTK_TagOrScriptPolicyList to use to determine whether the play area cursor collisions will be acted upon. If a list is provided then the 'Ignore Target With Tag Or Class' parameter will be ignored.")]
+        public VRTK_TagOrScriptPolicyList targetTagOrScriptListPolicy;
         [Tooltip("Determines when the pointer beam should be displayed.")]
         public pointerVisibilityStates pointerVisibility = pointerVisibilityStates.On_When_Active;
         [Tooltip("If this is checked then the pointer beam will be activated on first press of the pointer alias button and will stay active until the pointer alias button is pressed again. The destination set event is emitted when the beam is deactivated on the second button press.")]
@@ -307,7 +309,7 @@ namespace VRTK
             {
                 validNavMeshLocation = true;
             }
-            return (validNavMeshLocation && target && target.tag != invalidTargetWithTagOrClass && target.GetComponent(invalidTargetWithTagOrClass) == null);
+            return (validNavMeshLocation && target && !(Utilities.TagOrScriptCheck(target.gameObject, invalidTagOrScriptListPolicy, invalidTargetWithTagOrClass)));
         }
 
         private bool PointerActivatesUseAction(VRTK_InteractableObject io)
@@ -431,7 +433,7 @@ namespace VRTK
 
             var playAreaCursorScript = playAreaCursor.AddComponent<VRTK_PlayAreaCollider>();
             playAreaCursorScript.SetParent(gameObject);
-            playAreaCursorScript.SetIgnoreTarget(ignoreTargetWithTagOrClass);
+            playAreaCursorScript.SetIgnoreTarget(ignoreTargetWithTagOrClass, targetTagOrScriptListPolicy);
             playAreaCursor.layer = LayerMask.NameToLayer("Ignore Raycast");
 
             var playAreaBoundaryX = playArea.transform.localScale.x / 2;
@@ -467,20 +469,22 @@ namespace VRTK
     {
         private GameObject parent;
         private string ignoreTargetWithTagOrClass;
+        private VRTK_TagOrScriptPolicyList targetTagOrScriptListPolicy;
 
         public void SetParent(GameObject setParent)
         {
             parent = setParent;
         }
 
-        public void SetIgnoreTarget(string ignore)
+        public void SetIgnoreTarget(string ignore, VRTK_TagOrScriptPolicyList list = null)
         {
             ignoreTargetWithTagOrClass = ignore;
+            targetTagOrScriptListPolicy = list;
         }
 
         private bool ValidTarget(Collider collider)
         {
-            return (!collider.GetComponent<VRTK_PlayerObject>() & collider.tag != ignoreTargetWithTagOrClass && collider.GetComponent(ignoreTargetWithTagOrClass) == null);
+            return (!collider.GetComponent<VRTK_PlayerObject>() && !(Utilities.TagOrScriptCheck(collider.gameObject, targetTagOrScriptListPolicy, ignoreTargetWithTagOrClass)));
         }
 
         private void OnTriggerStay(Collider collider)

--- a/Assets/VRTK/Scripts/Helper/Utilities.cs
+++ b/Assets/VRTK/Scripts/Helper/Utilities.cs
@@ -119,5 +119,17 @@
                 Vector3.Dot(n, Vector3.Cross(v1, v2)),
                 Vector3.Dot(v1, v2)) * Mathf.Rad2Deg;
         }
+
+        public static bool TagOrScriptCheck(GameObject obj, VRTK_TagOrScriptPolicyList tagOrScriptList, string ignoreString)
+        {
+            if (tagOrScriptList)
+            {
+                return tagOrScriptList.Find(obj);
+            }
+            else
+            {
+                return (obj.tag == ignoreString || obj.GetComponent(ignoreString) != null);
+            }
+        }
     }
 }

--- a/Assets/VRTK/Scripts/Helper/VRTK_EventSystemVRInput.cs
+++ b/Assets/VRTK/Scripts/Helper/VRTK_EventSystemVRInput.cs
@@ -79,17 +79,22 @@
             return false;
         }
 
-        private bool ShouldIgnoreElement(GameObject obj, string ignoreCanvasWithTagOrClass)
+        private bool ShouldIgnoreElement(GameObject obj, string ignoreCanvasWithTagOrClass, VRTK_TagOrScriptPolicyList canvasTagOrScriptListPolicy)
         {
             var canvas = obj.GetComponentInParent<Canvas>();
-            return (canvas && (canvas.gameObject.tag == ignoreCanvasWithTagOrClass || canvas.GetComponent(ignoreCanvasWithTagOrClass) != null));
+            if (!canvas)
+            {
+                return false;
+            }
+
+            return (Utilities.TagOrScriptCheck(canvas.gameObject, canvasTagOrScriptListPolicy, ignoreCanvasWithTagOrClass));
         }
 
         private void Hover(VRTK_UIPointer pointer, List<RaycastResult> results)
         {
             if (pointer.pointerEventData.pointerEnter)
             {
-                if (ShouldIgnoreElement(pointer.pointerEventData.pointerEnter, pointer.ignoreCanvasWithTagOrClass))
+                if (ShouldIgnoreElement(pointer.pointerEventData.pointerEnter, pointer.ignoreCanvasWithTagOrClass, pointer.canvasTagOrScriptListPolicy))
                 {
                     return;
                 }
@@ -105,7 +110,7 @@
             {
                 foreach (var result in results)
                 {
-                    if (ShouldIgnoreElement(result.gameObject, pointer.ignoreCanvasWithTagOrClass))
+                    if (ShouldIgnoreElement(result.gameObject, pointer.ignoreCanvasWithTagOrClass, pointer.canvasTagOrScriptListPolicy))
                     {
                         continue;
                     }
@@ -152,7 +157,7 @@
 
             if (pointer.pointerEventData.pointerPress)
             {
-                if (ShouldIgnoreElement(pointer.pointerEventData.pointerPress, pointer.ignoreCanvasWithTagOrClass))
+                if (ShouldIgnoreElement(pointer.pointerEventData.pointerPress, pointer.ignoreCanvasWithTagOrClass, pointer.canvasTagOrScriptListPolicy))
                 {
                     return;
                 }
@@ -176,7 +181,7 @@
             {
                 foreach (var result in results)
                 {
-                    if (ShouldIgnoreElement(result.gameObject, pointer.ignoreCanvasWithTagOrClass))
+                    if (ShouldIgnoreElement(result.gameObject, pointer.ignoreCanvasWithTagOrClass, pointer.canvasTagOrScriptListPolicy))
                     {
                         continue;
                     }
@@ -199,7 +204,7 @@
 
             if (pointer.pointerEventData.pointerDrag)
             {
-                if (ShouldIgnoreElement(pointer.pointerEventData.pointerDrag, pointer.ignoreCanvasWithTagOrClass))
+                if (ShouldIgnoreElement(pointer.pointerEventData.pointerDrag, pointer.ignoreCanvasWithTagOrClass, pointer.canvasTagOrScriptListPolicy))
                 {
                     return;
                 }
@@ -226,7 +231,7 @@
             {
                 foreach (var result in results)
                 {
-                    if (ShouldIgnoreElement(result.gameObject, pointer.ignoreCanvasWithTagOrClass))
+                    if (ShouldIgnoreElement(result.gameObject, pointer.ignoreCanvasWithTagOrClass, pointer.canvasTagOrScriptListPolicy))
                     {
                         continue;
                     }
@@ -252,14 +257,14 @@
                 if (pointer.pointerEventData.scrollDelta != Vector2.zero)
                 {
                     var target = ExecuteEvents.ExecuteHierarchy(result.gameObject, pointer.pointerEventData, ExecuteEvents.scrollHandler);
-                    if(target)
+                    if (target)
                     {
                         scrollWheelVisible = true;
                     }
                 }
             }
 
-            if(pointer.controllerRenderModel)
+            if (pointer.controllerRenderModel)
             {
                 VRTK_SDK_Bridge.SetControllerRenderModelWheel(pointer.controllerRenderModel, scrollWheelVisible);
             }

--- a/Assets/VRTK/Scripts/VRTK_BasicTeleport.cs
+++ b/Assets/VRTK/Scripts/VRTK_BasicTeleport.cs
@@ -31,6 +31,8 @@ namespace VRTK
         public bool headsetPositionCompensation = true;
         [Tooltip("A string that specifies an object Tag or the name of a Script attached to an object and notifies the teleporter that the destination is to be ignored so the user cannot teleport to that location. It also ensure the pointer colour is set to the miss colour.")]
         public string ignoreTargetWithTagOrClass;
+        [Tooltip("A specified VRTK_TagOrScriptPolicyList to use to determine whether destination targets will be acted upon by the Teleporter. If a list is provided then the 'Ignore Target With Tag Or Class' parameter will be ignored.")]
+        public VRTK_TagOrScriptPolicyList targetTagOrScriptListPolicy;
         [Tooltip("The max distance the nav mesh edge can be from the teleport destination to be considered valid. If a value of `0` is given then the nav mesh restriction will be ignored.")]
         public float navMeshLimitDistance = 0f;
 
@@ -66,7 +68,7 @@ namespace VRTK
                     if (register)
                     {
                         worldMarker.DestinationMarkerSet += new DestinationMarkerEventHandler(DoTeleport);
-                        worldMarker.SetInvalidTarget(ignoreTargetWithTagOrClass);
+                        worldMarker.SetInvalidTarget(ignoreTargetWithTagOrClass, targetTagOrScriptListPolicy);
                         worldMarker.SetNavMeshCheckDistance(navMeshLimitDistance);
                         worldMarker.SetHeadsetPositionCompensation(headsetPositionCompensation);
                     }
@@ -149,7 +151,7 @@ namespace VRTK
                 validNavMeshLocation = true;
             }
 
-            return (validNavMeshLocation && target && target.tag != ignoreTargetWithTagOrClass && target.GetComponent(ignoreTargetWithTagOrClass) == null);
+            return (validNavMeshLocation && target && !(Utilities.TagOrScriptCheck(target.gameObject, targetTagOrScriptListPolicy, ignoreTargetWithTagOrClass)));
         }
 
         protected virtual void DoTeleport(object sender, DestinationMarkerEventArgs e)

--- a/Assets/VRTK/Scripts/VRTK_HeadsetCollision.cs
+++ b/Assets/VRTK/Scripts/VRTK_HeadsetCollision.cs
@@ -36,6 +36,8 @@ namespace VRTK
     {
         [Tooltip("A string that specifies an object Tag or the name of a Script attached to an object and will be ignored on headset collision.")]
         public string ignoreTargetWithTagOrClass;
+        [Tooltip("A specified VRTK_TagOrScriptPolicyList to use to determine whether any objects will be acted upon by the Headset Collision. If a list is provided then the 'Ignore Target With Tag Or Class' parameter will be ignored.")]
+        public VRTK_TagOrScriptPolicyList targetTagOrScriptListPolicy;
 
         /// <summary>
         /// Emitted when the user's headset collides with another game object.
@@ -106,7 +108,7 @@ namespace VRTK
 
         private bool ValidTarget(Transform target)
         {
-            return (target && target.tag != ignoreTargetWithTagOrClass && target.GetComponent(ignoreTargetWithTagOrClass) == null);
+            return (target && !(Utilities.TagOrScriptCheck(target.gameObject, targetTagOrScriptListPolicy, ignoreTargetWithTagOrClass)));
         }
 
         private void OnTriggerStay(Collider collider)

--- a/Assets/VRTK/Scripts/VRTK_HeadsetCollisionFade.cs
+++ b/Assets/VRTK/Scripts/VRTK_HeadsetCollisionFade.cs
@@ -24,6 +24,8 @@ namespace VRTK
         public Color fadeColor = Color.black;
         [Tooltip("A string that specifies an object Tag or the name of a Script attached to an object and will prevent the object from fading the headset view on collision.")]
         public string ignoreTargetWithTagOrClass;
+        [Tooltip("A specified VRTK_TagOrScriptPolicyList to use to determine whether any objects will be acted upon by the Headset Collision Fade. If a list is provided then the 'Ignore Target With Tag Or Class' parameter will be ignored.")]
+        public VRTK_TagOrScriptPolicyList targetTagOrScriptListPolicy;
 
         private VRTK_HeadsetCollision headsetCollision;
         private VRTK_HeadsetFade headsetFade;
@@ -32,6 +34,7 @@ namespace VRTK
         {
             headsetCollision = gameObject.AddComponent<VRTK_HeadsetCollision>();
             headsetCollision.ignoreTargetWithTagOrClass = ignoreTargetWithTagOrClass;
+            headsetCollision.targetTagOrScriptListPolicy = targetTagOrScriptListPolicy;
 
             headsetFade = gameObject.AddComponent<VRTK_HeadsetFade>();
 

--- a/Assets/VRTK/Scripts/VRTK_TagOrScriptPolicyList.cs
+++ b/Assets/VRTK/Scripts/VRTK_TagOrScriptPolicyList.cs
@@ -1,0 +1,120 @@
+﻿// Tag Or Script Policy List|Scripts|0225
+namespace VRTK
+{
+    using UnityEngine;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// The Tag Or Script Policy List allows to create a list of either tag names or script names that can be checked against to see if another operation is permitted.
+    /// </summary>
+    /// <remarks>
+    /// A number of other scripts can use a Tag Or Script Policy List to determine if an operation is permitted based on whether a game object has a tag applied or a script component on it.
+    ///
+    /// For example, the Teleporter scripts can ignore game object targets as a teleport location if the game object contains a tag that is in the identifiers list and the policy is set to ignore.
+    ///
+    /// Or the teleporter can only allow teleport to targets that contain a tag that is in the identifiers list and the policy is set to include.
+    ///
+    /// Add the Tag Or Script Policy List script to a game object (preferably the same component utilising the list) and then configure the list accordingly.
+    ///
+    /// Then in the component that has a Tag Or Script Policy List paramter (e.g. BasicTeleporter has `Target Tag Or Script List Policy`) simply select the list that has been created and defined.
+    /// </remarks>
+    public class VRTK_TagOrScriptPolicyList : MonoBehaviour
+    {
+        /// <summary>
+        /// The operation to apply on the list of identifiers.
+        /// </summary>
+        /// <param name="Ignore">Will ignore any game objects that contain either a tag or script component that is included in the identifiers list.</param>
+        /// <param name="Include">Will only include game objects that contain either a tag or script component that is included in the identifiers list.</param>
+        public enum OperationTypes
+        {
+            Ignore,
+            Include
+        }
+
+        /// <summary>
+        /// The types of element that can be checked against.
+        /// </summary>
+        /// <param name="Tag">The tag applied to the game object.</param>
+        /// <param name="Script">A script component added to the game object.</param>
+        /// <param name="Tag_Or_Script">Either a tag applied to the game object or a script component added to the game object.</param>
+        public enum CheckTypes
+        {
+            Tag,
+            Script,
+            Tag_Or_Script
+        }
+
+        [Tooltip("The operation to apply on the list of identifiers.")]
+        public OperationTypes operation = OperationTypes.Ignore;
+        [Tooltip("The element type on the game object to check against.")]
+        public CheckTypes checkType = CheckTypes.Tag;
+        [Tooltip("A list of identifiers to check for against the given check type (either tag or script).")]
+        public List<string> identifiers = new List<string>() { "" };
+
+        /// <summary>
+        /// The Find method performs the set operation to determine if the given game object contains one of the identifiers on the set check type.
+        /// </summary>
+        /// <remarks>
+        /// For instance, if the Operation is `Ignore` and the Check Type is `Tag` then the Find method will attempt to see if the given game object has a tag that matches one of the identifiers.
+        /// </remarks>
+        /// <param name="obj">The game object to check if it has a tag or script that is listed in the identifiers list.</param>
+        /// <returns>If the operation is `Ignore` and the game object is matched by an identifier from the list then it returns true. If the operation is `Include` and the game object is not matched by an identifier from the list then it returns true.</returns>
+        public bool Find(GameObject obj)
+        {
+            if (operation == OperationTypes.Ignore)
+            {
+                return TypeCheck(obj, true);
+            }
+            else
+            {
+                return TypeCheck(obj, false);
+            }
+        }
+
+        private bool ScriptCheck(GameObject obj, bool returnState)
+        {
+            foreach (var identifier in identifiers)
+            {
+                if (obj.GetComponent(identifier))
+                {
+                    return returnState;
+                }
+            }
+            return !returnState;
+        }
+
+        private bool TagCheck(GameObject obj, bool returnState)
+        {
+            if (returnState)
+            {
+                return identifiers.Contains(obj.tag);
+            }
+            else
+            {
+                return !identifiers.Contains(obj.tag);
+            }
+        }
+
+        private bool TypeCheck(GameObject obj, bool returnState)
+        {
+            switch (checkType)
+            {
+                case CheckTypes.Script:
+                    return ScriptCheck(obj, returnState);
+                case CheckTypes.Tag:
+                    return TagCheck(obj, returnState);
+                case CheckTypes.Tag_Or_Script:
+                    if ((returnState && ScriptCheck(obj, returnState)) || (!returnState && !ScriptCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    if ((returnState && TagCheck(obj, returnState)) || (!returnState && !TagCheck(obj, returnState)))
+                    {
+                        return returnState;
+                    }
+                    break;
+            }
+            return !returnState;
+        }
+    }
+}

--- a/Assets/VRTK/Scripts/VRTK_TagOrScriptPolicyList.cs.meta
+++ b/Assets/VRTK/Scripts/VRTK_TagOrScriptPolicyList.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 2ed2aa1a29b92ca4f84a26a5f6e9218b
+timeCreated: 1473628045
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/VRTK_UIPointer.cs
+++ b/Assets/VRTK/Scripts/VRTK_UIPointer.cs
@@ -59,6 +59,8 @@ namespace VRTK
         public string ignoreCanvasWithTagOrClass;
         [Tooltip("Determines when the UI pointer should be active.")]
         public ActivationMethods activationMode = ActivationMethods.Hold_Button;
+        [Tooltip("A specified VRTK_TagOrScriptPolicyList to use to determine whether any world canvases will be acted upon by the UI Pointer. If a list is provided then the 'Ignore Canvas With Tag Or Class' parameter will be ignored.")]
+        public VRTK_TagOrScriptPolicyList canvasTagOrScriptListPolicy;
 
         [HideInInspector]
         public PointerEventData pointerEventData;
@@ -142,7 +144,7 @@ namespace VRTK
         /// <param name="canvas">The canvas object to initialise for use with the UI pointers. Must be of type `WorldSpace`.</param>
         public void SetWorldCanvas(Canvas canvas)
         {
-            if (canvas.renderMode != RenderMode.WorldSpace || canvas.gameObject.tag == ignoreCanvasWithTagOrClass || canvas.GetComponent(ignoreCanvasWithTagOrClass) != null)
+            if (canvas.renderMode != RenderMode.WorldSpace || Utilities.TagOrScriptCheck(canvas.gameObject, canvasTagOrScriptListPolicy, ignoreCanvasWithTagOrClass))
             {
                 return;
             }
@@ -184,7 +186,7 @@ namespace VRTK
         /// <returns>Returns true if the ui pointer should be currently active.</returns>
         public bool PointerActive()
         {
-            if(activationMode == ActivationMethods.Always_On)
+            if (activationMode == ActivationMethods.Always_On)
             {
                 return true;
             }
@@ -201,7 +203,7 @@ namespace VRTK
                 }
                 lastPointerPressState = controller.pointerPressed;
 
-                if(pointerClicked)
+                if (pointerClicked)
                 {
                     beamEnabledState = !beamEnabledState;
                 }

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -279,16 +279,17 @@ Adding the `VRTK_DestinationMarker_UnityEvents` component to `VRTK_DestinationMa
 
 ### Class Methods
 
-#### SetInvalidTarget/1
+#### SetInvalidTarget/2
 
-  > `public virtual void SetInvalidTarget(string name)`
+  > `public virtual void SetInvalidTarget(string name, VRTK_TagOrScriptPolicyList list = null)`
 
   * Parameters
    * `string name` - The name of the tag or class that is the invalid target.
+   * `VRTK_TagOrScriptPolicyList list` - The Tag Or Script list policy to check the set operation on.
   * Returns
    * _none_
 
-The SetInvalidTarget method is used to set objects that contain the given tag or class matching the name as invalid destination targets.
+The SetInvalidTarget method is used to set objects that contain the given tag or class matching the name as invalid destination targets. It can also accept a VRTK_TagOrScriptPolicyList for a more custom level of policy management.
 
 #### SetNavMeshCheckDistance/1
 
@@ -333,6 +334,7 @@ The play area collider does not work well with terrains as they are uneven and c
  * **Play Area Cursor Dimensions:** Determines the size of the play area cursor and collider. If the values are left as zero then the Play Area Cursor will be sized to the calibrated Play Area space.
  * **Handle Play Area Cursor Collisions:** If this is ticked then if the play area cursor is colliding with any other object then the pointer colour will change to the `Pointer Miss Color` and the `WorldPointerDestinationSet` event will not be triggered, which will prevent teleporting into areas where the play area will collide.
  * **Ignore Target With Tag Or Class:** A string that specifies an object Tag or the name of a Script attached to an object and notifies the play area cursor to ignore collisions with the object.
+ * **Target Tag Or Script List Policy:** A specified VRTK_TagOrScriptPolicyList to use to determine whether the play area cursor collisions will be acted upon. If a list is provided then the 'Ignore Target With Tag Or Class' parameter will be ignored.
  * **Pointer Visibility:** Determines when the pointer beam should be displayed.
  * **Hold Button To Activate:** If this is checked then the pointer beam will be activated on first press of the pointer alias button and will stay active until the pointer alias button is pressed again. The destination set event is emitted when the beam is deactivated on the second button press.
  * **Activate Delay:** The time in seconds to delay the pointer beam being able to be active again. Useful for preventing constant teleportation.
@@ -418,6 +420,7 @@ This directory contains all of the toolkit scripts that add VR functionality to 
  * [Object Auto Grab](#object-auto-grab-vrtk_objectautograb)
  * [Player Climb](#player-climb-vrtk_playerclimb)
  * [Dash Teleport](#dash-teleport-vrtk_dashteleport)
+ * [Tag Or Script Policy List](#tag-or-script-policy-list-vrtk_tagorscriptpolicylist)
  * [Simulating Headset Movement](#simulating-headset-movement-vrtk_simulator)
 
 ---
@@ -1096,6 +1099,7 @@ The UI pointer is activated via the `Pointer` alias on the `Controller Events` a
  * **Controller:** The controller that will be used to toggle the pointer. If the script is being applied onto a controller then this parameter can be left blank as it will be auto populated by the controller the script is on at runtime.
  * **Ignore Canvas With Tag Or Class:** A string that specifies a canvas Tag or the name of a Script attached to a canvas and denotes that any world canvases that contain this tag or script will be ignored by the UI Pointer.
  * **Activation Mode:** Determines when the UI pointer should be active.
+ * **Canvas Tag Or Script List Policy:** A specified VRTK_TagOrScriptPolicyList to use to determine whether any world canvases will be acted upon by the UI Pointer. If a list is provided then the 'Ignore Canvas With Tag Or Class' parameter will be ignored.
 
 ### Class Variables
 
@@ -1177,6 +1181,7 @@ The Basic Teleport script is attached to the `[CameraRig]` prefab.
  * **Distance Blink Delay:** A range between 0 and 32 that determines how long the blink transition will stay blacked out depending on the distance being teleported. A value of 0 will not delay the teleport blink effect over any distance, a value of 32 will delay the teleport blink fade in even when the distance teleported is very close to the original position. This can be used to simulate time taking longer to pass the further a user teleports. A value of 16 provides a decent basis to simulate this to the user.
  * **Headset Position Compensation:** If this is checked then the teleported location will be the position of the headset within the play area. If it is unchecked then the teleported location will always be the centre of the play area even if the headset position is not in the centre of the play area.
  * **Ignore Target With Tag Or Class:** A string that specifies an object Tag or the name of a Script attached to an object and notifies the teleporter that the destination is to be ignored so the user cannot teleport to that location. It also ensure the pointer colour is set to the miss colour.
+ * **Target Tag Or Script List Policy:** A specified VRTK_TagOrScriptPolicyList to use to determine whether destination targets will be acted upon by the Teleporter. If a list is provided then the 'Ignore Target With Tag Or Class' parameter will be ignored.
  * **Nav Mesh Limit Distance:** The max distance the nav mesh edge can be from the teleport destination to be considered valid. If a value of `0` is given then the nav mesh restriction will be ignored.
 
 ### Class Events
@@ -1280,6 +1285,7 @@ The purpose of the Headset Collision is to detect when the user's VR headset col
 ### Inspector Parameters
 
  * **Ignore Target With Tag Or Class:** A string that specifies an object Tag or the name of a Script attached to an object and will be ignored on headset collision.
+ * **Target Tag Or Script List Policy:** A specified VRTK_TagOrScriptPolicyList to use to determine whether any objects will be acted upon by the Headset Collision. If a list is provided then the 'Ignore Target With Tag Or Class' parameter will be ignored.
 
 ### Class Events
 
@@ -1418,6 +1424,7 @@ The Headset Collision Fade uses a composition of the Headset Collision and Heads
  * **Blink Transition Speed:** The fade blink speed on collision.
  * **Fade Color:** The colour to fade the headset to on collision.
  * **Ignore Target With Tag Or Class:** A string that specifies an object Tag or the name of a Script attached to an object and will prevent the object from fading the headset view on collision.
+ * **Target Tag Or Script List Policy:** A specified VRTK_TagOrScriptPolicyList to use to determine whether any objects will be acted upon by the Headset Collision Fade. If a list is provided then the 'Ignore Target With Tag Or Class' parameter will be ignored.
 
 ### Example
 
@@ -2320,6 +2327,52 @@ Adding the `VRTK_DashTeleport_UnityEvents` component to `VRTK_DashTeleport` obje
 ### Example
 
 `SteamVR_Unity_Toolkit/Examples/038_CameraRig_DashTeleport` shows how to turn off the mesh renderers of objects that are in the way during the dash.
+
+---
+
+## Tag Or Script Policy List (VRTK_TagOrScriptPolicyList)
+
+### Overview
+
+The Tag Or Script Policy List allows to create a list of either tag names or script names that can be checked against to see if another operation is permitted.
+
+A number of other scripts can use a Tag Or Script Policy List to determine if an operation is permitted based on whether a game object has a tag applied or a script component on it.
+
+For example, the Teleporter scripts can ignore game object targets as a teleport location if the game object contains a tag that is in the identifiers list and the policy is set to ignore.
+
+Or the teleporter can only allow teleport to targets that contain a tag that is in the identifiers list and the policy is set to include.
+
+Add the Tag Or Script Policy List script to a game object (preferably the same component utilising the list) and then configure the list accordingly.
+
+Then in the component that has a Tag Or Script Policy List paramter (e.g. BasicTeleporter has `Target Tag Or Script List Policy`) simply select the list that has been created and defined.
+
+### Inspector Parameters
+
+ * **Operation:** The operation to apply on the list of identifiers.
+ * **Check Type:** The element type on the game object to check against.
+
+### Class Variables
+
+ * `public enum OperationTypes` - The operation to apply on the list of identifiers.
+  * `Ignore` - Will ignore any game objects that contain either a tag or script component that is included in the identifiers list.
+  * `Include` - Will only include game objects that contain either a tag or script component that is included in the identifiers list.
+ * `public enum CheckTypes` - The types of element that can be checked against.
+  * `Tag` - The tag applied to the game object.
+  * `Script` - A script component added to the game object.
+  * `Tag_Or_Script` - Either a tag applied to the game object or a script component added to the game object.
+
+### Class Methods
+
+#### Find/1
+
+  > `public bool Find(GameObject obj)`
+
+  * Parameters
+   * `GameObject obj` - The game object to check if it has a tag or script that is listed in the identifiers list.
+  * Returns
+   * `bool` - If the operation is `Ignore` and the game object is matched by an identifier from the list then it returns true. If the operation is `Include` and the game object is not matched by an identifier from the list then it returns true.
+
+The Find method performs the set operation to determine if the given game object contains one of the identifiers on the set check type. For instance, if the Operation is `Ignore` and the Check Type is `Tag` then the Find method will attempt to see if the given game object has a tag that matches one of the identifiers.
 
 ---
 


### PR DESCRIPTION
Previously, many of the classes utilised a single string to determine
whether something should be ignored by a tag or a script on the
component.

For example, the Teleport scripts could have a single tag or class name
provided to ignore any game objects containing that tag or named
component and treat it as an invalid teleport location.

This was very limiting as it only allowed for a single tag or class to
be specified and was always based on the items had to be in the ignore
list to be limited.

The new Tag Or Script Policy List script can now be added to a
component and have multiple tags or script name elements checked
against and can also have the operation set to `Ignore` to provide
the current behaviour, or be set to `Include` to only allow operations
on identifier matches.

This means for instance that the teleport script can be set up to
only teleport to areas that have a tag or script applied that is
in the list (rather than building a list of areas that cannot be
teleported to).

The existing Ignore With Tag Or Class string field has been left in
for legacy purposes and in case there are any unforseeable issues
with this new policy list. But it should be deprecated and then
removed in the future.