### PR TITLE
fix(Pointer): set destination correctly for constant beam - resolves #566

### DIFF
--- a/Assets/VRTK/Scripts/Abstractions/VRTK_WorldPointer.cs
+++ b/Assets/VRTK/Scripts/Abstractions/VRTK_WorldPointer.cs
@@ -233,9 +233,15 @@ namespace VRTK
             StopUseAction();
         }
 
+        private bool InvalidConstantBeam()
+        {
+            var equalToggleSet = controller.pointerToggleButton == controller.pointerSetButton;
+            return (!holdButtonToActivate && ((equalToggleSet && beamEnabledState != 0) || (!equalToggleSet && !isActive)));
+        }
+
         protected virtual void PointerSet()
         {
-            if (!enabled || !destinationSetActive || !pointerContactTarget || !CanActivate() || (!holdButtonToActivate && beamEnabledState != 0))
+            if (!enabled || !destinationSetActive || !pointerContactTarget || !CanActivate() || InvalidConstantBeam())
             {
                 return;
             }


### PR DESCRIPTION
If the `holdButtonToActivate` variable was set to false so there
was a constant pointer beam and if the pointer toggle and pointer set
alias buttons were different then the destination set event would be
emitted at the wrong time.

It would not emit the destination set event whilst the pointer beam
was still active, but would then allow the destination set event
after the pointer beam had been turned off.

This has been resolved with some additional checking in the pointer
set logic.