### PR TITLE
fix(Editor): prevent interactable object rumble values from switching

### DIFF
--- a/Assets/VRTK/Editor/VRTK_InteractableObjectEditor.cs
+++ b/Assets/VRTK/Editor/VRTK_InteractableObjectEditor.cs
@@ -38,10 +38,10 @@
                 EditorGUILayout.PrefixLabel("Rumble on Touch:");
                 EditorGUI.indentLevel--;
                 GUILayout.Label("Strength", GUILayout.MinWidth(49f));
-                float x = EditorGUILayout.FloatField(targ.rumbleOnTouch.x, GUILayout.MinWidth(10f));
-                GUILayout.Label("Duration", GUILayout.MinWidth(50f));
                 float y = EditorGUILayout.FloatField(targ.rumbleOnTouch.y, GUILayout.MinWidth(10f));
-                targ.rumbleOnTouch = new Vector2(y, x);
+                GUILayout.Label("Duration", GUILayout.MinWidth(50f));
+                float x = EditorGUILayout.FloatField(targ.rumbleOnTouch.x, GUILayout.MinWidth(10f));
+                targ.rumbleOnTouch = new Vector2(x, y);
                 EditorGUI.indentLevel++;
                 GUILayout.EndHorizontal();
 
@@ -80,10 +80,10 @@
                     EditorGUILayout.PrefixLabel("Rumble on Grab:");
                     EditorGUI.indentLevel--;
                     GUILayout.Label("Strength", GUILayout.MinWidth(49f));
-                    float x = EditorGUILayout.FloatField(targ.rumbleOnGrab.x, GUILayout.MinWidth(10f));
-                    GUILayout.Label("Duration", GUILayout.MinWidth(50f));
                     float y = EditorGUILayout.FloatField(targ.rumbleOnGrab.y, GUILayout.MinWidth(10f));
-                    targ.rumbleOnGrab = new Vector2(y, x);
+                    GUILayout.Label("Duration", GUILayout.MinWidth(50f));
+                    float x = EditorGUILayout.FloatField(targ.rumbleOnGrab.x, GUILayout.MinWidth(10f));
+                    targ.rumbleOnGrab = new Vector2(x, y);
                     EditorGUI.indentLevel++;
                     GUILayout.EndHorizontal();
 
@@ -143,10 +143,10 @@
                     EditorGUILayout.PrefixLabel("Rumble on Use:");
                     EditorGUI.indentLevel--;
                     GUILayout.Label("Strength", GUILayout.MinWidth(49f));
-                    float x = EditorGUILayout.FloatField(targ.rumbleOnUse.x, GUILayout.MinWidth(10f));
-                    GUILayout.Label("Duration", GUILayout.MinWidth(50f));
                     float y = EditorGUILayout.FloatField(targ.rumbleOnUse.y, GUILayout.MinWidth(10f));
-                    targ.rumbleOnUse = new Vector2(y, x);
+                    GUILayout.Label("Duration", GUILayout.MinWidth(50f));
+                    float x = EditorGUILayout.FloatField(targ.rumbleOnUse.x, GUILayout.MinWidth(10f));
+                    targ.rumbleOnUse = new Vector2(x, y);
                     EditorGUI.indentLevel++;
                     GUILayout.EndHorizontal();
 


### PR DESCRIPTION
The Rumble parameters on the Interactable Object could potentially
switch around so strength would become duration and vice versa due
to how the editor logic was working.

This fix ensures they should always be the same way round.