### PR TITLE
fix(Colliders): ensure colliders scale properly

### DIFF
--- a/Assets/VRTK/Scripts/VRTK_InteractTouch.cs
+++ b/Assets/VRTK/Scripts/VRTK_InteractTouch.cs
@@ -401,6 +401,7 @@ namespace VRTK
                 {
                     controllerCollisionDetector = Instantiate(customRigidbodyObject, transform.position, transform.rotation) as GameObject;
                     controllerCollisionDetector.transform.SetParent(transform);
+                    controllerCollisionDetector.transform.localScale = transform.localScale;
                     destroyColliderOnDisable = true;
                 }
             }

--- a/Assets/VRTK/Scripts/VRTK_PlayerPresence.cs
+++ b/Assets/VRTK/Scripts/VRTK_PlayerPresence.cs
@@ -297,7 +297,7 @@ namespace VRTK
         private void UpdateCollider()
         {
             var playAreaHeightAdjustment = 0.009f;
-            var newpresenceColliderYSize = (headset.transform.position.y - headsetYOffset) - transform.position.y;
+            var newpresenceColliderYSize = (headset.transform.localPosition.y - headsetYOffset) - transform.localPosition.y;
             var newpresenceColliderYCenter = (newpresenceColliderYSize != 0 ? (newpresenceColliderYSize / 2) + playAreaHeightAdjustment : 0);
 
             if (presenceCollider)


### PR DESCRIPTION
The custom rigid body collider object needs to be scaled to match
the parent object's scale.

The PlayerPresence body collider now scales properly.