### PR TITLE
fix(Components): simplify getting components and child components

### DIFF
--- a/Assets/VRTK/Scripts/Helper/CurveGenerator.cs
+++ b/Assets/VRTK/Scripts/Helper/CurveGenerator.cs
@@ -304,27 +304,17 @@ namespace VRTK
 
         private void setMeshMaterial(GameObject item, Material material)
         {
-            if (item.GetComponent<MeshRenderer>())
+            foreach (MeshRenderer itemRenderer in item.GetComponentsInChildren<MeshRenderer>())
             {
-                item.GetComponent<MeshRenderer>().material = material;
-            }
-
-            foreach (MeshRenderer mr in item.GetComponentsInChildren<MeshRenderer>())
-            {
-                mr.material = material;
+                itemRenderer.material = material;
             }
         }
 
         private void setSkinnedMeshMaterial(GameObject item, Material material)
         {
-            if (item.GetComponent<SkinnedMeshRenderer>())
+            foreach (SkinnedMeshRenderer itemRenderer in item.GetComponentsInChildren<SkinnedMeshRenderer>())
             {
-                item.GetComponent<SkinnedMeshRenderer>().material = material;
-            }
-
-            foreach (SkinnedMeshRenderer mr in item.GetComponentsInChildren<SkinnedMeshRenderer>())
-            {
-                mr.material = material;
+                itemRenderer.material = material;
             }
         }
     }

--- a/Assets/VRTK/Scripts/Helper/Utilities.cs
+++ b/Assets/VRTK/Scripts/Helper/Utilities.cs
@@ -97,9 +97,9 @@
             return camera;
         }
 
-        public static void CreateColliders(GameObject go)
+        public static void CreateColliders(GameObject obj)
         {
-            Renderer[] renderers = go.GetComponentsInChildren<Renderer>();
+            Renderer[] renderers = obj.GetComponentsInChildren<Renderer>();
             foreach (Renderer renderer in renderers)
             {
                 if (!renderer.gameObject.GetComponent<Collider>())

--- a/Assets/VRTK/Scripts/VRTK_BezierPointer.cs
+++ b/Assets/VRTK/Scripts/VRTK_BezierPointer.cs
@@ -106,18 +106,23 @@ namespace VRTK
                     beamTraceMaterial = Instantiate(renderer.sharedMaterial);
                 }
             }
+
             if (customPointerCursor)
             {
-                Renderer renderer = customPointerCursor.GetComponentInChildren<MeshRenderer>();
-                if (renderer != null)
+                var customPointerCursorRenderer = customPointerCursor.GetComponentInChildren<MeshRenderer>();
+
+                if (customPointerCursorRenderer != null)
                 {
-                    customPointerMaterial = Instantiate(renderer.sharedMaterial);
+                    customPointerMaterial = Instantiate(customPointerCursorRenderer.sharedMaterial);
                 }
+
                 pointerCursor = Instantiate(customPointerCursor);
-                foreach (Renderer mr in pointerCursor.GetComponentsInChildren<Renderer>())
+
+                foreach (var pointerCursorRenderer in pointerCursor.GetComponentsInChildren<Renderer>())
                 {
-                    mr.material = customPointerMaterial;
+                    pointerCursorRenderer.material = customPointerMaterial;
                 }
+
                 if (validTeleportLocationObject != null)
                 {
                     validTeleportLocationInstance = Instantiate(validTeleportLocationObject);
@@ -131,6 +136,7 @@ namespace VRTK
             {
                 pointerCursor = CreateCursor();
             }
+
             pointerCursor.name = string.Format("[{0}]WorldPointer_BezierPointer_PointerCursor", gameObject.name);
             Utilities.SetPlayerObject(pointerCursor, VRTK_PlayerObject.ObjectTypes.Pointer);
             pointerCursor.layer = LayerMask.NameToLayer("Ignore Raycast");
@@ -162,14 +168,9 @@ namespace VRTK
 
             if (customPointerCursor == null)
             {
-                if (pointerCursor.GetComponent<Renderer>())
+                foreach (var pointerCursorRenderers in pointerCursor.GetComponentsInChildren<Renderer>())
                 {
-                    pointerCursor.GetComponent<Renderer>().material = pointerMaterial;
-                }
-
-                foreach (Renderer mr in pointerCursor.GetComponentsInChildren<Renderer>())
-                {
-                    mr.material = pointerMaterial;
+                    pointerCursorRenderers.material = pointerMaterial;
                 }
             }
             base.SetPointerMaterial();

--- a/Assets/VRTK/Scripts/VRTK_InteractTouch.cs
+++ b/Assets/VRTK/Scripts/VRTK_InteractTouch.cs
@@ -146,11 +146,6 @@ namespace VRTK
             if (controllerCollisionDetector && touchRigidBody)
             {
                 touchRigidBody.isKinematic = !state;
-                foreach (var collider in controllerCollisionDetector.GetComponents<Collider>())
-                {
-                    collider.isTrigger = !state;
-                }
-
                 foreach (var collider in controllerCollisionDetector.GetComponentsInChildren<Collider>())
                 {
                     collider.isTrigger = !state;
@@ -372,7 +367,7 @@ namespace VRTK
         {
             foreach (var childTransform in GetComponentsInChildren<Transform>())
             {
-                if (childTransform == customRigidbodyObject.transform)
+                if (childTransform != transform && childTransform == customRigidbodyObject.transform)
                 {
                     return true;
                 }

--- a/Assets/VRTK/Scripts/VRTK_PlayerPresence.cs
+++ b/Assets/VRTK/Scripts/VRTK_PlayerPresence.cs
@@ -199,7 +199,6 @@ namespace VRTK
         {
             if(e.target)
             {
-                IgnoreCollisions(e.target.GetComponents<Collider>(), true);
                 IgnoreCollisions(e.target.GetComponentsInChildren<Collider>(), true);
             }
         }
@@ -208,7 +207,6 @@ namespace VRTK
         {
             if (e.target && e.target.GetComponent<VRTK_InteractableObject>())
             {
-                IgnoreCollisions(e.target.GetComponents<Collider>(), false);
                 IgnoreCollisions(e.target.GetComponentsInChildren<Collider>(), false);
             }
         }
@@ -351,7 +349,6 @@ namespace VRTK
         {
             if (controller)
             {
-                IgnoreCollisions(controller.GetComponents<Collider>(), true);
                 IgnoreCollisions(controller.GetComponentsInChildren<Collider>(), true);
 
                 var grabbingController = controller.GetComponent<VRTK_InteractGrab>();

--- a/Assets/VRTK/Scripts/VRTK_SimplePointer.cs
+++ b/Assets/VRTK/Scripts/VRTK_SimplePointer.cs
@@ -88,7 +88,7 @@ namespace VRTK
                 Renderer renderer = customPointerCursor.GetComponentInChildren<MeshRenderer>();
                 if (renderer)
                 {
-                    customPointerMaterial = Material.Instantiate(renderer.sharedMaterial);
+                    customPointerMaterial = Instantiate(renderer.sharedMaterial);
                 }
                 pointerTip = Instantiate(customPointerCursor);
                 foreach (Renderer mr in pointerTip.GetComponentsInChildren<Renderer>())


### PR DESCRIPTION
The `GetComponentsInChildren` method will also return any types
found on the current object as well so it's not required to do a
`GetComponents` to affect the current object and then followed by
`GetComponentsInChildren` to affect the child objects.

`GetComponentsInChildren` is enough to deal with all current object
types and all child types as well. It's inefficient to make the
call twice and update the same object in both calls.

There are still occasions where a check to see if the item exists
on the current object using `GetComponent` is valid, because it
it a cheaper call to execute and if the object contains the
component then doing the more expensive `GetComponentInChildren`
is not required to be made.