### PR TITLE
fix(Interaction): track every touching object instead of last one

### DIFF
--- a/Assets/VRTK/Scripts/VRTK_InteractTouch.cs
+++ b/Assets/VRTK/Scripts/VRTK_InteractTouch.cs
@@ -344,8 +344,8 @@ namespace VRTK
                 }
 
                 OnControllerUntouchInteractableObject(SetControllerInteractEvent(untouched.gameObject));
-                untouched.GetComponent<VRTK_InteractableObject>().ToggleHighlight(false);
                 untouched.GetComponent<VRTK_InteractableObject>().StopTouching(gameObject);
+                untouched.GetComponent<VRTK_InteractableObject>().ToggleHighlight(false);
             }
 
             if (updatedHideControllerOnTouch)


### PR DESCRIPTION
The Interactable Object would only track the last controller to touch
it, which caused issues when both controllers touched the object at the
same time because if one controller was removed then the Interactable
Object's touched status would be set to null even though another
controller was still touching it.

The fix is to keep a `List<>` of all objects that are touching the
Interactable Object rather than just a reference to the last object
that touched it.