### PR TITLE
fix(Controls): replace lever to use rotator track - resolves #582

### DIFF
--- a/Assets/VRTK/Scripts/Controls/3D/VRTK_Lever.cs
+++ b/Assets/VRTK/Scripts/Controls/3D/VRTK_Lever.cs
@@ -58,7 +58,7 @@ namespace VRTK
             io.isGrabbable = true;
             io.precisionSnap = true;
             io.stayGrabbedOnTeleport = false;
-            io.grabAttachMechanic = VRTK_InteractableObject.GrabAttachType.Track_Object;
+            io.grabAttachMechanic = VRTK_InteractableObject.GrabAttachType.Rotator_Track;
 
             hj = GetComponent<HingeJoint>();
             if (hj == null)


### PR DESCRIPTION
The lever now uses the Rotator_Track as the Track_Object grab mechanic doesn't work as well for moving the lever.