### PR TITLE
feat(UnityEvents): add sender object to unity event payload

### DIFF
--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_BasicTeleport_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_BasicTeleport_UnityEvents.cs
@@ -9,7 +9,7 @@
         private VRTK_BasicTeleport bt;
 
         [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<DestinationMarkerEventArgs> { };
+        public class UnityObjectEvent : UnityEvent<object, DestinationMarkerEventArgs> { };
 
         /// <summary>
         /// Emits the Teleporting class event.
@@ -43,12 +43,12 @@
 
         private void Teleporting(object o, DestinationMarkerEventArgs e)
         {
-            OnTeleporting.Invoke(e);
+            OnTeleporting.Invoke(o, e);
         }
 
         private void Teleported(object o, DestinationMarkerEventArgs e)
         {
-            OnTeleported.Invoke(e);
+            OnTeleported.Invoke(o, e);
         }
 
         private void OnDisable()

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_ControllerActions_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_ControllerActions_UnityEvents.cs
@@ -9,7 +9,7 @@
         private VRTK_ControllerActions ca;
 
         [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<ControllerActionsEventArgs> { };
+        public class UnityObjectEvent : UnityEvent<object, ControllerActionsEventArgs> { };
 
         /// <summary>
         /// Emits the ControllerModelVisible class event.
@@ -43,12 +43,12 @@
 
         private void ControllerModelVisible(object o, ControllerActionsEventArgs e)
         {
-            OnControllerModelVisible.Invoke(e);
+            OnControllerModelVisible.Invoke(o, e);
         }
 
         private void ControllerModelInvisible(object o, ControllerActionsEventArgs e)
         {
-            OnControllerModelInvisible.Invoke(e);
+            OnControllerModelInvisible.Invoke(o, e);
         }
 
         private void OnDisable()

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_ControllerEvents_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_ControllerEvents_UnityEvents.cs
@@ -9,7 +9,7 @@
         private VRTK_ControllerEvents ce;
 
         [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<ControllerInteractionEventArgs> { };
+        public class UnityObjectEvent : UnityEvent<object, ControllerInteractionEventArgs> { };
 
         /// <summary>
         /// Emits the TriggerPressed class event.
@@ -188,157 +188,157 @@
 
         private void TriggerPressed(object o, ControllerInteractionEventArgs e)
         {
-            OnTriggerPressed.Invoke(e);
+            OnTriggerPressed.Invoke(o, e);
         }
 
         private void TriggerReleased(object o, ControllerInteractionEventArgs e)
         {
-            OnTriggerReleased.Invoke(e);
+            OnTriggerReleased.Invoke(o, e);
         }
 
         private void TriggerTouchStart(object o, ControllerInteractionEventArgs e)
         {
-            OnTriggerTouchStart.Invoke(e);
+            OnTriggerTouchStart.Invoke(o, e);
         }
 
         private void TriggerTouchEnd(object o, ControllerInteractionEventArgs e)
         {
-            OnTriggerTouchEnd.Invoke(e);
+            OnTriggerTouchEnd.Invoke(o, e);
         }
 
         private void TriggerHairlineStart(object o, ControllerInteractionEventArgs e)
         {
-            OnTriggerHairlineStart.Invoke(e);
+            OnTriggerHairlineStart.Invoke(o, e);
         }
 
         private void TriggerHairlineEnd(object o, ControllerInteractionEventArgs e)
         {
-            OnTriggerHairlineEnd.Invoke(e);
+            OnTriggerHairlineEnd.Invoke(o, e);
         }
 
         private void TriggerClicked(object o, ControllerInteractionEventArgs e)
         {
-            OnTriggerClicked.Invoke(e);
+            OnTriggerClicked.Invoke(o, e);
         }
 
         private void TriggerUnclicked(object o, ControllerInteractionEventArgs e)
         {
-            OnTriggerUnclicked.Invoke(e);
+            OnTriggerUnclicked.Invoke(o, e);
         }
 
         private void TriggerAxisChanged(object o, ControllerInteractionEventArgs e)
         {
-            OnTriggerAxisChanged.Invoke(e);
+            OnTriggerAxisChanged.Invoke(o, e);
         }
 
         private void ApplicationMenuPressed(object o, ControllerInteractionEventArgs e)
         {
-            OnApplicationMenuPressed.Invoke(e);
+            OnApplicationMenuPressed.Invoke(o, e);
         }
 
         private void ApplicationMenuReleased(object o, ControllerInteractionEventArgs e)
         {
-            OnApplicationMenuReleased.Invoke(e);
+            OnApplicationMenuReleased.Invoke(o, e);
         }
 
         private void GripPressed(object o, ControllerInteractionEventArgs e)
         {
-            OnGripPressed.Invoke(e);
+            OnGripPressed.Invoke(o, e);
         }
 
         private void GripReleased(object o, ControllerInteractionEventArgs e)
         {
-            OnGripReleased.Invoke(e);
+            OnGripReleased.Invoke(o, e);
         }
 
         private void TouchpadPressed(object o, ControllerInteractionEventArgs e)
         {
-            OnTouchpadPressed.Invoke(e);
+            OnTouchpadPressed.Invoke(o, e);
         }
 
         private void TouchpadReleased(object o, ControllerInteractionEventArgs e)
         {
-            OnTouchpadReleased.Invoke(e);
+            OnTouchpadReleased.Invoke(o, e);
         }
 
         private void TouchpadTouchStart(object o, ControllerInteractionEventArgs e)
         {
-            OnTouchpadTouchStart.Invoke(e);
+            OnTouchpadTouchStart.Invoke(o, e);
         }
 
         private void TouchpadTouchEnd(object o, ControllerInteractionEventArgs e)
         {
-            OnTouchpadTouchEnd.Invoke(e);
+            OnTouchpadTouchEnd.Invoke(o, e);
         }
 
         private void TouchpadAxisChanged(object o, ControllerInteractionEventArgs e)
         {
-            OnTouchpadAxisChanged.Invoke(e);
+            OnTouchpadAxisChanged.Invoke(o, e);
         }
 
         private void AliasPointerOn(object o, ControllerInteractionEventArgs e)
         {
-            OnAliasPointerOn.Invoke(e);
+            OnAliasPointerOn.Invoke(o, e);
         }
 
         private void AliasPointerOff(object o, ControllerInteractionEventArgs e)
         {
-            OnAliasPointerOff.Invoke(e);
+            OnAliasPointerOff.Invoke(o, e);
         }
 
         private void AliasPointerSet(object o, ControllerInteractionEventArgs e)
         {
-            OnAliasPointerSet.Invoke(e);
+            OnAliasPointerSet.Invoke(o, e);
         }
 
         private void AliasGrabOn(object o, ControllerInteractionEventArgs e)
         {
-            OnAliasGrabOn.Invoke(e);
+            OnAliasGrabOn.Invoke(o, e);
         }
 
         private void AliasGrabOff(object o, ControllerInteractionEventArgs e)
         {
-            OnAliasGrabOff.Invoke(e);
+            OnAliasGrabOff.Invoke(o, e);
         }
 
         private void AliasUseOn(object o, ControllerInteractionEventArgs e)
         {
-            OnAliasUseOn.Invoke(e);
+            OnAliasUseOn.Invoke(o, e);
         }
 
         private void AliasUseOff(object o, ControllerInteractionEventArgs e)
         {
-            OnAliasUseOff.Invoke(e);
+            OnAliasUseOff.Invoke(o, e);
         }
 
         private void AliasUIClickOn(object o, ControllerInteractionEventArgs e)
         {
-            OnAliasUIClickOn.Invoke(e);
+            OnAliasUIClickOn.Invoke(o, e);
         }
 
         private void AliasUIClickOff(object o, ControllerInteractionEventArgs e)
         {
-            OnAliasUIClickOff.Invoke(e);
+            OnAliasUIClickOff.Invoke(o, e);
         }
 
         private void AliasMenuOn(object o, ControllerInteractionEventArgs e)
         {
-            OnAliasMenuOn.Invoke(e);
+            OnAliasMenuOn.Invoke(o, e);
         }
 
         private void AliasMenuOff(object o, ControllerInteractionEventArgs e)
         {
-            OnAliasMenuOff.Invoke(e);
+            OnAliasMenuOff.Invoke(o, e);
         }
 
         private void ControllerEnabled(object o, ControllerInteractionEventArgs e)
         {
-            OnControllerEnabled.Invoke(e);
+            OnControllerEnabled.Invoke(o, e);
         }
 
         private void ControllerDisabled(object o, ControllerInteractionEventArgs e)
         {
-            OnControllerDisabled.Invoke(e);
+            OnControllerDisabled.Invoke(o, e);
         }
 
         private void OnDisable()

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_DashTeleport_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_DashTeleport_UnityEvents.cs
@@ -9,7 +9,7 @@
         private VRTK_DashTeleport dt;
 
         [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<DashTeleportEventArgs> { };
+        public class UnityObjectEvent : UnityEvent<object, DashTeleportEventArgs> { };
 
         /// <summary>
         /// Emits the WillDashThruObjects class event.
@@ -43,12 +43,12 @@
 
         private void WillDashThruObjects(object o, DashTeleportEventArgs e)
         {
-            OnWillDashThruObjects.Invoke(e);
+            OnWillDashThruObjects.Invoke(o, e);
         }
 
         private void DashedThruObjects(object o, DashTeleportEventArgs e)
         {
-            OnDashedThruObjects.Invoke(e);
+            OnDashedThruObjects.Invoke(o, e);
         }
 
         private void OnDisable()

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_DestinationMarker_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_DestinationMarker_UnityEvents.cs
@@ -9,7 +9,7 @@
         private VRTK_DestinationMarker dm;
 
         [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<DestinationMarkerEventArgs> { };
+        public class UnityObjectEvent : UnityEvent<object, DestinationMarkerEventArgs> { };
 
         /// <summary>
         /// Emits the DestinationMarkerEnter class event.
@@ -48,17 +48,17 @@
 
         private void DestinationMarkerEnter(object o, DestinationMarkerEventArgs e)
         {
-            OnDestinationMarkerEnter.Invoke(e);
+            OnDestinationMarkerEnter.Invoke(o, e);
         }
 
         private void DestinationMarkerExit(object o, DestinationMarkerEventArgs e)
         {
-            OnDestinationMarkerExit.Invoke(e);
+            OnDestinationMarkerExit.Invoke(o, e);
         }
 
         private void DestinationMarkerSet(object o, DestinationMarkerEventArgs e)
         {
-            OnDestinationMarkerSet.Invoke(e);
+            OnDestinationMarkerSet.Invoke(o, e);
         }
 
         private void OnDisable()

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_HeadsetCollision_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_HeadsetCollision_UnityEvents.cs
@@ -9,7 +9,7 @@
         private VRTK_HeadsetCollision hc;
 
         [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<HeadsetCollisionEventArgs> { };
+        public class UnityObjectEvent : UnityEvent<object, HeadsetCollisionEventArgs> { };
 
         /// <summary>
         /// Emits the HeadsetCollisionDetect class event.
@@ -43,12 +43,12 @@
 
         private void HeadsetCollisionDetect(object o, HeadsetCollisionEventArgs e)
         {
-            OnHeadsetCollisionDetect.Invoke(e);
+            OnHeadsetCollisionDetect.Invoke(o, e);
         }
 
         private void HeadsetCollisionEnded(object o, HeadsetCollisionEventArgs e)
         {
-            OnHeadsetCollisionEnded.Invoke(e);
+            OnHeadsetCollisionEnded.Invoke(o, e);
         }
 
         private void OnDisable()

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_HeadsetFade_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_HeadsetFade_UnityEvents.cs
@@ -9,7 +9,7 @@
         private VRTK_HeadsetFade hf;
 
         [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<HeadsetFadeEventArgs> { };
+        public class UnityObjectEvent : UnityEvent<object, HeadsetFadeEventArgs> { };
 
         /// <summary>
         /// Emits the HeadsetFadeStart class event.
@@ -53,22 +53,22 @@
 
         private void HeadsetFadeStart(object o, HeadsetFadeEventArgs e)
         {
-            OnHeadsetFadeStart.Invoke(e);
+            OnHeadsetFadeStart.Invoke(o, e);
         }
 
         private void HeadsetFadeComplete(object o, HeadsetFadeEventArgs e)
         {
-            OnHeadsetFadeComplete.Invoke(e);
+            OnHeadsetFadeComplete.Invoke(o, e);
         }
 
         private void HeadsetUnfadeStart(object o, HeadsetFadeEventArgs e)
         {
-            OnHeadsetUnfadeStart.Invoke(e);
+            OnHeadsetUnfadeStart.Invoke(o, e);
         }
 
         private void HeadsetUnfadeComplete(object o, HeadsetFadeEventArgs e)
         {
-            OnHeadsetUnfadeComplete.Invoke(e);
+            OnHeadsetUnfadeComplete.Invoke(o, e);
         }
 
         private void OnDisable()

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_InteractGrab_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_InteractGrab_UnityEvents.cs
@@ -9,7 +9,7 @@
         private VRTK_InteractGrab ig;
 
         [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<ObjectInteractEventArgs> { };
+        public class UnityObjectEvent : UnityEvent<object, ObjectInteractEventArgs> { };
 
         /// <summary>
         /// Emits the ControllerGrabInteractableObject class event.
@@ -43,12 +43,12 @@
 
         private void ControllerGrabInteractableObject(object o, ObjectInteractEventArgs e)
         {
-            OnControllerGrabInteractableObject.Invoke(e);
+            OnControllerGrabInteractableObject.Invoke(o, e);
         }
 
         private void ControllerUngrabInteractableObject(object o, ObjectInteractEventArgs e)
         {
-            OnControllerUngrabInteractableObject.Invoke(e);
+            OnControllerUngrabInteractableObject.Invoke(o, e);
         }
 
         private void OnDisable()

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_InteractTouch_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_InteractTouch_UnityEvents.cs
@@ -9,7 +9,7 @@
         private VRTK_InteractTouch it;
 
         [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<ObjectInteractEventArgs> { };
+        public class UnityObjectEvent : UnityEvent<object, ObjectInteractEventArgs> { };
 
         /// <summary>
         /// Emits the ControllerTouchInteractableObject class event.
@@ -43,12 +43,12 @@
 
         private void ControllerTouchInteractableObject(object o, ObjectInteractEventArgs e)
         {
-            OnControllerTouchInteractableObject.Invoke(e);
+            OnControllerTouchInteractableObject.Invoke(o, e);
         }
 
         private void ControllerUntouchInteractableObject(object o, ObjectInteractEventArgs e)
         {
-            OnControllerUntouchInteractableObject.Invoke(e);
+            OnControllerUntouchInteractableObject.Invoke(o, e);
         }
 
         private void OnDisable()

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_InteractUse_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_InteractUse_UnityEvents.cs
@@ -9,7 +9,7 @@
         private VRTK_InteractUse iu;
 
         [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<ObjectInteractEventArgs> { };
+        public class UnityObjectEvent : UnityEvent<object, ObjectInteractEventArgs> { };
 
         /// <summary>
         /// Emits the ControllerUseInteractableObject class event.
@@ -43,12 +43,12 @@
 
         private void ControllerUseInteractableObject(object o, ObjectInteractEventArgs e)
         {
-            OnControllerUseInteractableObject.Invoke(e);
+            OnControllerUseInteractableObject.Invoke(o, e);
         }
 
         private void ControllerUnuseInteractableObject(object o, ObjectInteractEventArgs e)
         {
-            OnControllerUnuseInteractableObject.Invoke(e);
+            OnControllerUnuseInteractableObject.Invoke(o, e);
         }
 
         private void OnDisable()

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_InteractableObject_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_InteractableObject_UnityEvents.cs
@@ -9,7 +9,7 @@
         private VRTK_InteractableObject io;
 
         [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<InteractableObjectEventArgs> { };
+        public class UnityObjectEvent : UnityEvent<object, InteractableObjectEventArgs> { };
 
         /// <summary>
         /// Emits the InteractableObjectTouched class event.
@@ -63,32 +63,32 @@
 
         private void Touch(object o, InteractableObjectEventArgs e)
         {
-            OnTouch.Invoke(e);
+            OnTouch.Invoke(o, e);
         }
 
         private void UnTouch(object o, InteractableObjectEventArgs e)
         {
-            OnUntouch.Invoke(e);
+            OnUntouch.Invoke(o, e);
         }
 
         private void Grab(object o, InteractableObjectEventArgs e)
         {
-            OnGrab.Invoke(e);
+            OnGrab.Invoke(o, e);
         }
 
         private void UnGrab(object o, InteractableObjectEventArgs e)
         {
-            OnUngrab.Invoke(e);
+            OnUngrab.Invoke(o, e);
         }
 
         private void Use(object o, InteractableObjectEventArgs e)
         {
-            OnUse.Invoke(e);
+            OnUse.Invoke(o, e);
         }
 
         private void Unuse(object o, InteractableObjectEventArgs e)
         {
-            OnUnuse.Invoke(e);
+            OnUnuse.Invoke(o, e);
         }
 
         private void OnDisable()

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_PlayerClimb_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_PlayerClimb_UnityEvents.cs
@@ -9,7 +9,7 @@
         private VRTK_PlayerClimb pc;
 
         [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<PlayerClimbEventArgs> { };
+        public class UnityObjectEvent : UnityEvent<object, PlayerClimbEventArgs> { };
 
         /// <summary>
         /// Emits the PlayerClimbStarted class event.
@@ -43,12 +43,12 @@
 
         private void PlayerClimbStarted(object o, PlayerClimbEventArgs e)
         {
-            OnPlayerClimbStarted.Invoke(e);
+            OnPlayerClimbStarted.Invoke(o, e);
         }
 
         private void PlayerClimbEnded(object o, PlayerClimbEventArgs e)
         {
-            OnPlayerClimbEnded.Invoke(e);
+            OnPlayerClimbEnded.Invoke(o, e);
         }
 
         private void OnDisable()

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_PlayerPresence_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_PlayerPresence_UnityEvents.cs
@@ -9,7 +9,7 @@
         private VRTK_PlayerPresence pp;
 
         [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<PlayerPresenceEventArgs> { };
+        public class UnityObjectEvent : UnityEvent<object, PlayerPresenceEventArgs> { };
 
         /// <summary>
         /// Emits the PresenceFallStarted class event.
@@ -43,12 +43,12 @@
 
         private void PresenceFallStarted(object o, PlayerPresenceEventArgs e)
         {
-            OnPresenceFallStarted.Invoke(e);
+            OnPresenceFallStarted.Invoke(o, e);
         }
 
         private void PresenceFallEnded(object o, PlayerPresenceEventArgs e)
         {
-            OnPresenceFallEnded.Invoke(e);
+            OnPresenceFallEnded.Invoke(o, e);
         }
 
         private void OnDisable()

--- a/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_UIPointer_UnityEvents.cs
+++ b/Assets/VRTK/Scripts/Helper/UnityEvents/VRTK_UIPointer_UnityEvents.cs
@@ -9,7 +9,7 @@
         private VRTK_UIPointer uip;
 
         [System.Serializable]
-        public class UnityObjectEvent : UnityEvent<UIPointerEventArgs> { };
+        public class UnityObjectEvent : UnityEvent<object, UIPointerEventArgs> { };
 
         /// <summary>
         /// Emits the UIPointerElementEnter class event.
@@ -42,12 +42,12 @@
 
         private void UIPointerElementEnter(object o, UIPointerEventArgs e)
         {
-            OnUIPointerElementEnter.Invoke(e);
+            OnUIPointerElementEnter.Invoke(o, e);
         }
 
         private void UIPointerElementExit(object o, UIPointerEventArgs e)
         {
-            OnUIPointerElementExit.Invoke(e);
+            OnUIPointerElementExit.Invoke(o, e);
         }
 
         private void OnDisable()


### PR DESCRIPTION
All Unity Event helpers now send the sender object in the Unity Event
payload as well to match the delegate events correctly.