### PR TITLE
chore(Editor): ensure tooltips display in custom inspector editor

### DIFF
--- a/Assets/VRTK/Editor/VRTK_AdaptiveQualityEditor.cs
+++ b/Assets/VRTK/Editor/VRTK_AdaptiveQualityEditor.cs
@@ -99,14 +99,14 @@ namespace VRTK
                 }
 
                 adaptiveQuality.overrideRenderScale = EditorGUILayout.Toggle(
-                  CreateLabelWithTooltip(adaptiveQuality, "overrideRenderScale"),
+                  Utilities.BuildGUIContent<VRTK_AdaptiveQuality>("overrideRenderScale"),
                   adaptiveQuality.overrideRenderScale);
 
                 EditorGUI.BeginDisabledGroup(!adaptiveQuality.overrideRenderScale);
                 {
                     adaptiveQuality.overrideRenderScaleLevel =
                       EditorGUILayout.IntSlider(
-                        CreateLabelWithTooltip(adaptiveQuality, "overrideRenderScaleLevel"),
+                        Utilities.BuildGUIContent<VRTK_AdaptiveQuality>("overrideRenderScaleLevel"),
                         adaptiveQuality.overrideRenderScaleLevel,
                         0,
                         maxRenderScaleLevel);
@@ -125,14 +125,6 @@ namespace VRTK
 
             EditorGUILayout.Space();
             EditorGUILayout.LabelField(headerAttribute.header, EditorStyles.boldLabel);
-        }
-
-        private static GUIContent CreateLabelWithTooltip(VRTK_AdaptiveQuality adaptiveQuality, string fieldName)
-        {
-            var fieldInfo = adaptiveQuality.GetType().GetField(fieldName);
-            var tooltipAttribute = (TooltipAttribute)Attribute.GetCustomAttribute(fieldInfo, typeof(TooltipAttribute));
-
-            return new GUIContent(ObjectNames.NicifyVariableName(fieldName), tooltipAttribute.tooltip);
         }
     }
 }

--- a/Assets/VRTK/Scripts/Controls/3D/VRTK_Spring_Lever.cs
+++ b/Assets/VRTK/Scripts/Controls/3D/VRTK_Spring_Lever.cs
@@ -1,4 +1,4 @@
-﻿// Lever|Controls3D|0071
+﻿// Spring Lever|Controls3D|0071
 namespace VRTK
 {
     using UnityEngine;
@@ -11,7 +11,6 @@ namespace VRTK
     /// </remarks>
     public class VRTK_Spring_Lever : VRTK_Lever
     {
-
         [Tooltip("Strength of the spring force that will be applied toward either end of the lever's range.")]
         public float springStrength = 10;
 
@@ -66,6 +65,5 @@ namespace VRTK
                 wasTowardZero = towardZero;
             }
         }
-
     }
 }

--- a/Assets/VRTK/Scripts/Helper/Utilities.cs
+++ b/Assets/VRTK/Scripts/Helper/Utilities.cs
@@ -1,6 +1,8 @@
 ﻿namespace VRTK
 {
     using UnityEngine;
+    using UnityEditor;
+    using System;
     using System.Reflection;
     using Highlighters;
 
@@ -157,6 +159,14 @@
             }
 
             return objectHighlighter;
+        }
+
+        public static GUIContent BuildGUIContent<T>(string fieldName, string displayOverride = null)
+        {
+            var displayName = (displayOverride != null ? displayOverride : ObjectNames.NicifyVariableName(fieldName));
+            var fieldInfo = typeof(T).GetField(fieldName);
+            var tooltipAttribute = (TooltipAttribute)Attribute.GetCustomAttribute(fieldInfo, typeof(TooltipAttribute));
+            return (tooltipAttribute == null ? new GUIContent(displayName) : new GUIContent(displayName, tooltipAttribute.tooltip));
         }
     }
 }

--- a/Assets/VRTK/Scripts/VRTK_InteractableObject.cs
+++ b/Assets/VRTK/Scripts/VRTK_InteractableObject.cs
@@ -83,6 +83,7 @@ namespace VRTK
         }
 
         [Header("Touch Interactions", order = 1)]
+
         [Tooltip("The object will only highlight when a controller touches it if this is checked.")]
         public bool highlightOnTouch = false;
         [Tooltip("The colour to highlight the object when it is touched. This colour will override any globally set colour (for instance on the `VRTK_InteractTouch` script).")]
@@ -95,9 +96,10 @@ namespace VRTK
         public ControllerHideMode hideControllerOnTouch = ControllerHideMode.Default;
 
         [Header("Grab Interactions", order = 2)]
+
         [Tooltip("Determines if the object can be grabbed.")]
         public bool isGrabbable = false;
-        [Tooltip("Determines if the object can be dropped by the controller grab button being used. If this is unchecked then it's not possible to drop the item once it's picked up using the controller button. It is still possible for the item to be dropped if the Grab Attach Mechanic is a joint and too much force is applied to the object and the joint is broken. To prevent this it's better to use the Child Of Controller mechanic.")]
+        [Tooltip("Determines if the object can be dropped by the controller grab button being used. If this is unchecked then it's not possible to drop the item once it's picked up using the controller button.")]
         public bool isDroppable = true;
         [Tooltip("Determines if the object can be swapped between controllers when it is picked up. If it is unchecked then the object must be dropped before it can be picked up by the other controller.")]
         public bool isSwappable = true;
@@ -121,6 +123,7 @@ namespace VRTK
         public bool stayGrabbedOnTeleport = true;
 
         [Header("Grab Mechanics", order = 3)]
+
         [Tooltip("This determines how the grabbed item will be attached to the controller when it is grabbed.")]
         public GrabAttachType grabAttachMechanic = GrabAttachType.Fixed_Joint;
         [Tooltip("The force amount when to detach the object from the grabbed controller. If the controller tries to exert a force higher than this threshold on the object (from pulling it through another object or pushing it into another object) then the joint holding the object to the grabbing controller will break and the object will no longer be grabbed. This also works with Tracked Object grabbing but determines how far the controller is from the object before breaking the grab. Only required for `Fixed Joint`, `Spring Joint`, `Track Object` and `Rotator Track`.")]
@@ -135,9 +138,10 @@ namespace VRTK
         public float onGrabCollisionDelay = 0f;
 
         [Header("Use Interactions", order = 4)]
+
         [Tooltip("Determines if the object can be used.")]
         public bool isUsable = false;
-        [Tooltip("If this is checked the object can be used only if it was grabbed before.")]
+        [Tooltip("If this is checked the object can be used only if it is currently being grabbed.")]
         public bool useOnlyIfGrabbed = false;
         [Tooltip("If this is checked then the use button on the controller needs to be continually held down to keep using. If this is unchecked the the use button toggles the use action with one button press to start using and another to stop using.")]
         public bool holdButtonToUse = true;

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1842,7 +1842,7 @@ The highlighting of an Interactable Object is defaulted to use the `VRTK_Materia
  * **Allowed Touch Controllers:** Determines which controller can initiate a touch action.
  * **Hide Controller On Touch:** Optionally override the controller setting.
  * **Is Grabbable:** Determines if the object can be grabbed.
- * **Is Droppable:** Determines if the object can be dropped by the controller grab button being used. If this is unchecked then it's not possible to drop the item once it's picked up using the controller button. It is still possible for the item to be dropped if the Grab Attach Mechanic is a joint and too much force is applied to the object and the joint is broken. To prevent this it's better to use the Child Of Controller mechanic.
+ * **Is Droppable:** Determines if the object can be dropped by the controller grab button being used. If this is unchecked then it's not possible to drop the item once it's picked up using the controller button.
  * **Is Swappable:** Determines if the object can be swapped between controllers when it is picked up. If it is unchecked then the object must be dropped before it can be picked up by the other controller.
  * **Hold Button To Grab:** If this is checked then the grab button on the controller needs to be continually held down to keep grabbing. If this is unchecked the grab button toggles the grab action with one button press to grab and another to release.
  * **Grab Override Button:** If this is set to `Undefined` then the global grab alias button will grab the object, setting it to any other button will ensure the override button is used to grab this specific interactable object.
@@ -1860,7 +1860,7 @@ The highlighting of an Interactable Object is defaulted to use the `VRTK_Materia
  * **Throw Multiplier:** An amount to multiply the velocity of the given object when it is thrown. This can also be used in conjunction with the Interact Grab Throw Multiplier to have certain objects be thrown even further than normal (or thrown a shorter distance if a number below 1 is entered).
  * **On Grab Collision Delay:** The amount of time to delay collisions affecting the object when it is first grabbed. This is useful if a game object may get stuck inside another object when it is being grabbed.
  * **Is Usable:** Determines if the object can be used.
- * **Use Only If Grabbed:** If this is checked the object can be used only if it was grabbed before.
+ * **Use Only If Grabbed:** If this is checked the object can be used only if it is currently being grabbed.
  * **Hold Button To Use:** If this is checked then the use button on the controller needs to be continually held down to keep using. If this is unchecked the the use button toggles the use action with one button press to start using and another to stop using.
  * **Use Override Button:** If this is set to `Undefined` then the global use alias button will use the object, setting it to any other button will ensure the override button is used to use this specific interactable object.
  * **Pointer Activates Use Action:** If this is checked then when a World Pointer beam (projected from the controller) hits the interactable object, if the object has `Hold Button To Use` unchecked then whilst the pointer is over the object it will run it's `Using` method. If `Hold Button To Use` is unchecked then the `Using` method will be run when the pointer is deactivated. The world pointer will not throw the `Destination Set` event if it is affecting an interactable object with this setting checked as this prevents unwanted teleporting from happening when using an object with a pointer.
@@ -2772,6 +2772,7 @@ All 3D controls extend the `VRTK_Control` abstract class which provides common m
  * [Drawer](#drawer-vrtk_drawer)
  * [Knob](#knob-vrtk_knob)
  * [Lever](#lever-vrtk_lever)
+ * [Spring Lever](#spring-lever-vrtk_spring_lever)
  * [Slider](#slider-vrtk_slider)
 
 ---
@@ -2989,6 +2990,21 @@ The script will instantiate the required Rigidbody, Interactable and HingeJoint 
 ### Example
 
 `VRTK/Examples/025_Controls_Overview` has a couple of levers that can be grabbed and moved. One lever is horizontal and the other is vertical.
+
+---
+
+## Spring Lever (VRTK_Spring_Lever)
+ > extends [VRTK_Lever](#lever-vrtk_lever)
+
+### Overview
+
+This script extends VRTK_Lever to add spring force toward whichever end of the lever's range it is closest to.
+
+The script will instantiate the required Rigidbody, Interactable and HingeJoint components automatically in case they do not exist yet. The joint is very tricky to setup automatically though and will only work in straight forward cases. If there are any issues, then create the HingeJoint component manually and configure it as needed.
+
+### Inspector Parameters
+
+ * **Spring Strength:** Strength of the spring force that will be applied toward either end of the lever's range.
 
 ---
 


### PR DESCRIPTION
The custom inspector editor for the Interactable Object now displays
the tooltips from the Interactable Object script via a shared Utility
method for getting the class tooltip. The Adapative Quality Editor
now also uses this shared Utility method.