### PR TITLE
fix(AdaptiveQuality): only allow for Unity 5.4 and above

### DIFF
--- a/Assets/VRTK/Editor/VRTK_AdaptiveQualityEditor.cs
+++ b/Assets/VRTK/Editor/VRTK_AdaptiveQualityEditor.cs
@@ -1,3 +1,4 @@
+#if (UNITY_5_4_OR_NEWER)
 namespace VRTK
 {
     using System;
@@ -128,3 +129,4 @@ namespace VRTK
         }
     }
 }
+#endif

--- a/Assets/VRTK/Scripts/VRTK_AdaptiveQuality.cs
+++ b/Assets/VRTK/Scripts/VRTK_AdaptiveQuality.cs
@@ -3,6 +3,9 @@
 // Adapted from The Lab Renderer's ValveCamera.cs, available at
 // https://github.com/ValveSoftware/the_lab_renderer/blob/ae64c48a8ccbe5406aba1e39b160d4f2f7156c2c/Assets/TheLabRenderer/Scripts/ValveCamera.cs
 // For The Lab Renderer's license see THIRD_PARTY_NOTICES.
+// **Only Compatible With Unity 5.4 and above**
+
+#if (UNITY_5_4_OR_NEWER)
 namespace VRTK
 {
     using System;
@@ -16,6 +19,8 @@ namespace VRTK
     /// Adaptive Quality dynamically changes rendering settings to maintain VR framerate while maximizing GPU utilization.
     /// </summary>
     /// <remarks>
+    ///   > **Only Compatible With Unity 5.4 and above**
+    ///
     /// The Adaptive Quality script is attached to the `eye` object within the `[CameraRig]` prefab.
     /// <para>&#160;</para>
     /// There are two goals:
@@ -329,7 +334,7 @@ namespace VRTK
             UpdateMSAALevel();
         }
 
-#endregion
+        #endregion
 
         private void HandleCommandLineArguments()
         {
@@ -379,7 +384,7 @@ namespace VRTK
 
         private void HandleKeyPresses()
         {
-            if (!respondsToKeyboardShortcuts|| !(Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift)))
+            if (!respondsToKeyboardShortcuts || !(Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift)))
             {
                 return;
             }
@@ -418,7 +423,7 @@ namespace VRTK
             }
         }
 
-#region Render scale methods
+        #region Render scale methods
 
         private void UpdateRenderScaleLevels()
         {
@@ -605,9 +610,9 @@ namespace VRTK
             }
         }
 
-#endregion
+        #endregion
 
-#region Debug visualization methods
+        #region Debug visualization methods
 
         private void CreateOrDestroyDebugVisualization()
         {
@@ -676,9 +681,9 @@ namespace VRTK
             debugVisualizationQuadMaterial.SetInt(ShaderPropertyIDs.LastFrameIsInBudget, lastFrameIsInBudget);
         }
 
-#endregion
+        #endregion
 
-#region Private helper classes
+        #region Private helper classes
 
         private static class CommandLineArguments
         {
@@ -704,6 +709,7 @@ namespace VRTK
             public static readonly int LastFrameIsInBudget = Shader.PropertyToID("_LastFrameIsInBudget");
         }
 
-#endregion
+        #endregion
     }
 }
+#endif

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2655,6 +2655,8 @@ The Simulator script is attached to the `[CameraRig]` prefab. Supported movement
 
 Adaptive Quality dynamically changes rendering settings to maintain VR framerate while maximizing GPU utilization.
 
+> **Only Compatible With Unity 5.4 and above**
+
 The Adaptive Quality script is attached to the `eye` object within the `[CameraRig]` prefab.
 
 There are two goals:

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -216,4 +216,6 @@ A scene that shows the teleporting behaviour and also demonstrates a way to use 
 
 ### 039_CameraRig_AdaptiveQuality
 
+  > **Only Compatible With Unity 5.4 and above**
+
 A scene displays the frames per second in the centre of the headset view. The debug visualization of this script is displayed near the top edge of the headset view. Pressing the trigger generates a new sphere and pressing the touchpad generates ten new spheres. Eventually when lots of spheres are present the FPS will drop and demonstrate the script.


### PR DESCRIPTION
Unity 5.3 and below do not support many of the Unity.VR features
used by the Adaptive Quality script so the entire code block has been
wrapped to only allow it to execute in Unity 5.4 and above.