### PR TITLE
feat(InteractGrab) add toggle to auto-scale throw velocity with player

### DIFF
--- a/Assets/VRTK/Scripts/VRTK_InteractGrab.cs
+++ b/Assets/VRTK/Scripts/VRTK_InteractGrab.cs
@@ -37,6 +37,8 @@ namespace VRTK
         public float grabPrecognition = 0f;
         [Tooltip("An amount to multiply the velocity of any objects being thrown. This can be useful when scaling up the `[CameraRig]` to simulate being able to throw items further.")]
         public float throwMultiplier = 1f;
+        [Tooltip("Automatically scale the throw velocity up and down to match the scale of the `[CameraRig]`.")]
+        public bool throwScalesWithPlayer = true;
         [Tooltip("If this is checked and the controller is not touching an Interactable Object when the grab button is pressed then a rigid body is added to the controller to allow the controller to push other rigid body objects around.")]
         public bool createRigidBodyWhenNotTouching = false;
 
@@ -323,7 +325,9 @@ namespace VRTK
 
             if (origin != null)
             {
-                rb.velocity = origin.TransformDirection(velocity) * (throwMultiplier * objectThrowMultiplier);
+                Vector3 worldSpaceVelocity = throwScalesWithPlayer ? origin.TransformVector(velocity) : origin.TransformDirection(velocity);
+
+                rb.velocity = worldSpaceVelocity * (throwMultiplier * objectThrowMultiplier);
                 rb.angularVelocity = origin.TransformDirection(angularVelocity);
             }
             else


### PR DESCRIPTION
A boolean toggle is now used to determine if the user wants the throw
velocity to scale up and down with the camera rig. To get around this
issue before, you had to manually enter the scale in the mulitpier
slot which is error prone and a bit confusing. This toggle keeps all
velocities used to throw in true world space coordinates, so dynamic
size adjustments and throwing just work without any additional input
needed from the developer.