### PR TITLE
feat(ControllerEvents): get controller magnitude for swing speed

### DIFF
--- a/Assets/VRTK/Scripts/VRTK_ControllerEvents.cs
+++ b/Assets/VRTK/Scripts/VRTK_ControllerEvents.cs
@@ -579,7 +579,8 @@ namespace VRTK
         /// The GetMagnitude method is used to return the current magnitude of the physical game controller. This can be useful for determining the speed at which the controller is being swung.
         /// </summary>
         /// <returns>A float illustrating the length of the vector based on current real world physical controller velocity.</returns>
-        public float GetMagnitude() {
+        public float GetMagnitude()
+        {
             SetVelocity();
             return controllerMagnitude;
         }

--- a/Assets/VRTK/Scripts/VRTK_ControllerEvents.cs
+++ b/Assets/VRTK/Scripts/VRTK_ControllerEvents.cs
@@ -305,6 +305,7 @@ namespace VRTK
         private float hairTriggerDelta;
         private Vector3 controllerVelocity = Vector3.zero;
         private Vector3 controllerAngularVelocity = Vector3.zero;
+        private float controllerMagnitude = 0;
 
         public virtual void OnTriggerPressed(ControllerInteractionEventArgs e)
         {
@@ -572,6 +573,15 @@ namespace VRTK
         {
             SetVelocity();
             return controllerAngularVelocity;
+        }
+
+        /// <summary>
+        /// The GetMagnitude method is useful for getting the current magnitude of the physical game controller. This can be useful for determining the speed at which the controller is moving.
+        /// </summary>
+        /// <returns>A float illustrating the length of the vector based on current real world physical controller velocity.</returns>
+        public float GetMagnitude() {
+            SetVelocity();
+            return controllerMagnitude;
         }
 
         /// <summary>
@@ -1009,8 +1019,9 @@ namespace VRTK
 
         private void SetVelocity()
         {
-            controllerVelocity = VRTK_SDK_Bridge.GetVelocityOnIndex(controllerIndex); ;
-            controllerAngularVelocity = VRTK_SDK_Bridge.GetAngularVelocityOnIndex(controllerIndex); ;
+            controllerVelocity = VRTK_SDK_Bridge.GetVelocityOnIndex(controllerIndex);
+            controllerAngularVelocity = VRTK_SDK_Bridge.GetAngularVelocityOnIndex(controllerIndex);
+            controllerMagnitude = Vector3.Magnitude(controllerVelocity);
         }
     }
 }

--- a/Assets/VRTK/Scripts/VRTK_ControllerEvents.cs
+++ b/Assets/VRTK/Scripts/VRTK_ControllerEvents.cs
@@ -576,7 +576,7 @@ namespace VRTK
         }
 
         /// <summary>
-        /// The GetMagnitude method is useful for getting the current magnitude of the physical game controller. This can be useful for determining the speed at which the controller is moving.
+        /// The GetMagnitude method is used to return the current magnitude of the physical game controller. This can be useful for determining the speed at which the controller is being swung.
         /// </summary>
         /// <returns>A float illustrating the length of the vector based on current real world physical controller velocity.</returns>
         public float GetMagnitude() {


### PR DESCRIPTION
Apologies if this isn't done right -- my first pull request on GH! This was brought up as a question on Slack (and one of my own yesterday). It might be too self-explanatory, but as someone who didn't know Vector3.Magnitude was available, I'm hoping to remove any headaches others who want to use this for items like sword swing detection and other motion-based gestures.

Also removed a few double semicolons in the existing code.