### PR TITLE
fix(InteractGrab): scaled player throw velocity matches world size

### DIFF
--- a/Assets/VRTK/Scripts/VRTK_InteractGrab.cs
+++ b/Assets/VRTK/Scripts/VRTK_InteractGrab.cs
@@ -323,7 +323,7 @@ namespace VRTK
 
             if (origin != null)
             {
-                rb.velocity = origin.TransformDirection(velocity) * (throwMultiplier * objectThrowMultiplier);
+                rb.velocity = origin.TransformVector(velocity) * (throwMultiplier * objectThrowMultiplier);
                 rb.angularVelocity = origin.TransformDirection(angularVelocity);
             }
             else


### PR DESCRIPTION
The throw velocity now takes the scale of the player into
consideration. This allows the user to dynamically scale the
player up and down without having to worry about manually
adjusting the throw multiplier to regain expected results.