### PR TITLE
feat(Pointer): separate play area cursor into own script

### DIFF
--- a/Assets/VRTK/Examples/012_Controller_PointerWithAreaCollision.unity
+++ b/Assets/VRTK/Examples/012_Controller_PointerWithAreaCollision.unity
@@ -406,6 +406,134 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 385480578}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!43 &666944310
+Mesh:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: 
+  serializedVersion: 8
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 24
+    topology: 0
+    firstVertex: 0
+    vertexCount: 8
+    localAABB:
+      m_Center: {x: 0, y: 0.01, z: 0}
+      m_Extent: {x: 1.2, y: 0, z: 1.0500002}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexBuffer: 000004000100010004000500010005000200020005000600020006000300030006000700030007000000000007000400
+  m_Skin: []
+  m_VertexData:
+    m_CurrentChannels: 13
+    m_VertexCount: 8
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 28
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 288
+    _typelessdata: 6766863f0ad7233c696666bf000000000000803f0000803f0000803f0000000000000000676686bf0ad7233c696666bf000000000000803f0000803f0000803f0000803f00000000676686bf0ad7233c6966663f000000000000803f0000803f0000803f00000000000000006766863f0ad7233c6966663f000000000000803f0000803f0000803f0000803f000000009a99993f0ad7233c686686bf000000000000803f0000803f00000000000000000000803f9a9999bf0ad7233c686686bf000000000000803f0000803f000000000000803f0000803f9a9999bf0ad7233c6866863f000000000000803f0000803f00000000000000000000803f9a99993f0ad7233c6866863f000000000000803f0000803f000000000000803f0000803f
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0, y: 0.01, z: 0}
+    m_Extent: {x: 1.2, y: 0, z: 1.0500002}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshOptimized: 0
 --- !u!1 &678749675
 GameObject:
   m_ObjectHideFlags: 0
@@ -606,7 +734,7 @@ Prefab:
     - target: {fileID: 3380982, guid: 4d293c8e162f3874b982baadd71153d2, type: 2}
       propertyPath: m_Mesh
       value: 
-      objectReference: {fileID: 1243941328}
+      objectReference: {fileID: 666944310}
     - target: {fileID: 11489174, guid: 4d293c8e162f3874b982baadd71153d2, type: 2}
       propertyPath: drawWireframeWhenSelectedOnly
       value: 0
@@ -683,6 +811,10 @@ Prefab:
       propertyPath: vertices.Array.data[7].z
       value: 0.9000001
       objectReference: {fileID: 0}
+    - target: {fileID: 2348914, guid: 4d293c8e162f3874b982baadd71153d2, type: 2}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 1691321011}
     m_RemovedComponents:
     - {fileID: 11411836, guid: 4d293c8e162f3874b982baadd71153d2, type: 2}
   m_ParentPrefab: {fileID: 100100000, guid: 4d293c8e162f3874b982baadd71153d2, type: 2}
@@ -718,11 +850,14 @@ MonoBehaviour:
   distanceBlinkDelay: 0
   headsetPositionCompensation: 1
   ignoreTargetWithTagOrClass: 
+  targetTagOrScriptListPolicy: {fileID: 0}
   navMeshLimitDistance: 0
   playSpaceFalling: 1
+  playSpaceFallRestriction: 0
   useGravity: 0
   gravityFallHeight: 1
   blinkYThreshold: 0.1
+  floorHeightTolerance: 0.001
 --- !u!114 &872323749
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -739,10 +874,6 @@ MonoBehaviour:
   pointerMaterial: {fileID: 0}
   pointerHitColor: {r: 0, g: 0.5, b: 0, a: 1}
   pointerMissColor: {r: 0.8, g: 0, b: 0, a: 1}
-  showPlayAreaCursor: 1
-  playAreaCursorDimensions: {x: 0, y: 0}
-  handlePlayAreaCursorCollisions: 1
-  ignoreTargetWithTagOrClass: 
   pointerVisibility: 0
   holdButtonToActivate: 1
   activateDelay: 0
@@ -750,7 +881,9 @@ MonoBehaviour:
   pointerDensity: 10
   showPointerCursor: 1
   pointerCursorRadius: 0.5
+  pointerCursorMatchTargetRotation: 0
   beamCurveOffset: 1
+  beamHeightLimitAngle: 100
   customPointerTracer: {fileID: 0}
   customPointerCursor: {fileID: 0}
   layersToIgnore:
@@ -776,6 +909,7 @@ MonoBehaviour:
   uiClickButton: 3
   menuToggleButton: 7
   axisFidelity: 1
+  triggerClickThreshold: 1
   triggerPressed: 0
   triggerTouched: 0
   triggerHairlinePressed: 0
@@ -807,10 +941,6 @@ MonoBehaviour:
   pointerMaterial: {fileID: 0}
   pointerHitColor: {r: 0, g: 0.5, b: 0, a: 1}
   pointerMissColor: {r: 0.8, g: 0, b: 0, a: 1}
-  showPlayAreaCursor: 1
-  playAreaCursorDimensions: {x: 0, y: 0}
-  handlePlayAreaCursorCollisions: 1
-  ignoreTargetWithTagOrClass: 
   pointerVisibility: 0
   holdButtonToActivate: 1
   activateDelay: 0
@@ -818,7 +948,9 @@ MonoBehaviour:
   pointerDensity: 10
   showPointerCursor: 1
   pointerCursorRadius: 0.5
+  pointerCursorMatchTargetRotation: 0
   beamCurveOffset: 1
+  beamHeightLimitAngle: 100
   customPointerTracer: {fileID: 0}
   customPointerCursor: {fileID: 0}
   layersToIgnore:
@@ -844,6 +976,7 @@ MonoBehaviour:
   uiClickButton: 3
   menuToggleButton: 7
   axisFidelity: 1
+  triggerClickThreshold: 1
   triggerPressed: 0
   triggerTouched: 0
   triggerHairlinePressed: 0
@@ -882,20 +1015,21 @@ MonoBehaviour:
   _ears: {fileID: 872323753}
   wireframe: 0
   flip: {fileID: 0}
---- !u!114 &872323756
+--- !u!114 &872323769
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 872323754}
+  m_GameObject: {fileID: 872323745}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 21b4bc319f4966f4faedb4f429f7c9c9, type: 3}
+  m_Script: {fileID: 11500000, guid: 9d7236ea6e01c074ba249e564af997a0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  blinkTransitionSpeed: 0.1
-  fadeColor: {r: 0, g: 0, b: 0, a: 1}
+  playAreaCursorDimensions: {x: 0, y: 0}
+  handlePlayAreaCursorCollisions: 1
   ignoreTargetWithTagOrClass: 
+  targetTagOrScriptListPolicy: {fileID: 0}
 --- !u!1 &884550209
 GameObject:
   m_ObjectHideFlags: 0
@@ -1486,134 +1620,6 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1214114803}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!43 &1243941328
-Mesh:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_Name: 
-  serializedVersion: 8
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 24
-    topology: 0
-    firstVertex: 0
-    vertexCount: 8
-    localAABB:
-      m_Center: {x: 0, y: 0.01, z: 0}
-      m_Extent: {x: 1.2499999, y: 0, z: 0.9000001}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexBuffer: 000001000400010005000400010002000500020006000500020003000600030007000600030000000700000004000700
-  m_Skin: []
-  m_VertexData:
-    m_CurrentChannels: 13
-    m_VertexCount: 8
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 28
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 288
-    _typelessdata: cccc8c3f0ad7233c020040bf000000000000803f0000803f0000803f0000000000000000cccc8cbf0ad7233c020040bf000000000000803f0000803f0000803f0000803f00000000cccc8cbf0ad7233c0200403f000000000000803f0000803f0000803f0000000000000000cccc8c3f0ad7233c0200403f000000000000803f0000803f0000803f0000803f00000000ffff9f3f0ad7233c686666bf000000000000803f0000803f00000000000000000000803fffff9fbf0ad7233c686666bf000000000000803f0000803f000000000000803f0000803fffff9fbf0ad7233c6866663f000000000000803f0000803f00000000000000000000803fffff9f3f0ad7233c6866663f000000000000803f0000803f000000000000803f0000803f
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 0, y: 0.01, z: 0}
-    m_Extent: {x: 1.2499999, y: 0, z: 0.9000001}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshOptimized: 0
 --- !u!1 &1327507133
 GameObject:
   m_ObjectHideFlags: 0
@@ -2089,6 +2095,35 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 5
+--- !u!21 &1691321011
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Sprites/Default
+  m_Shader: {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 5
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  m_SavedProperties:
+    serializedVersion: 2
+    m_TexEnvs:
+    - first:
+        name: _MainTex
+      second:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - first:
+        name: PixelSnap
+      second: 0
+    m_Colors:
+    - first:
+        name: _Color
+      second: {r: 1, g: 1, b: 1, a: 1}
 --- !u!1 &1907973908
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/VRTK/Examples/031_CameraRig_HeadsetGazePointer.unity
+++ b/Assets/VRTK/Examples/031_CameraRig_HeadsetGazePointer.unity
@@ -169,6 +169,134 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1907973909}
   m_RootOrder: 5
+--- !u!43 &28898311
+Mesh:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: 
+  serializedVersion: 8
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 24
+    topology: 0
+    firstVertex: 0
+    vertexCount: 8
+    localAABB:
+      m_Center: {x: 0, y: 0.01, z: 0}
+      m_Extent: {x: 1.2, y: 0, z: 1.0500002}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexBuffer: 000004000100010004000500010005000200020005000600020006000300030006000700030007000000000007000400
+  m_Skin: []
+  m_VertexData:
+    m_CurrentChannels: 13
+    m_VertexCount: 8
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 28
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 288
+    _typelessdata: 6766863f0ad7233c696666bf000000000000803f0000803f0000803f0000000000000000676686bf0ad7233c696666bf000000000000803f0000803f0000803f0000803f00000000676686bf0ad7233c6966663f000000000000803f0000803f0000803f00000000000000006766863f0ad7233c6966663f000000000000803f0000803f0000803f0000803f000000009a99993f0ad7233c686686bf000000000000803f0000803f00000000000000000000803f9a9999bf0ad7233c686686bf000000000000803f0000803f000000000000803f0000803f9a9999bf0ad7233c6866863f000000000000803f0000803f00000000000000000000803f9a99993f0ad7233c6866863f000000000000803f0000803f000000000000803f0000803f
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0, y: 0.01, z: 0}
+    m_Extent: {x: 1.2, y: 0, z: 1.0500002}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshOptimized: 0
 --- !u!1 &51027536
 GameObject:
   m_ObjectHideFlags: 0
@@ -644,134 +772,6 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 385480578}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!43 &414083819
-Mesh:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_Name: 
-  serializedVersion: 8
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 24
-    topology: 0
-    firstVertex: 0
-    vertexCount: 8
-    localAABB:
-      m_Center: {x: 0, y: 0.01, z: 0}
-      m_Extent: {x: 1.2499999, y: 0, z: 0.9000001}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexBuffer: 000001000400010005000400010002000500020006000500020003000600030007000600030000000700000004000700
-  m_Skin: []
-  m_VertexData:
-    m_CurrentChannels: 13
-    m_VertexCount: 8
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 28
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 288
-    _typelessdata: cccc8c3f0ad7233c020040bf000000000000803f0000803f0000803f0000000000000000cccc8cbf0ad7233c020040bf000000000000803f0000803f0000803f0000803f00000000cccc8cbf0ad7233c0200403f000000000000803f0000803f0000803f0000000000000000cccc8c3f0ad7233c0200403f000000000000803f0000803f0000803f0000803f00000000ffff9f3f0ad7233c686666bf000000000000803f0000803f00000000000000000000803fffff9fbf0ad7233c686666bf000000000000803f0000803f000000000000803f0000803fffff9fbf0ad7233c6866663f000000000000803f0000803f00000000000000000000803fffff9f3f0ad7233c6866663f000000000000803f0000803f000000000000803f0000803f
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 0, y: 0.01, z: 0}
-    m_Extent: {x: 1.2499999, y: 0, z: 0.9000001}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshOptimized: 0
 --- !u!1001 &470380167
 Prefab:
   m_ObjectHideFlags: 0
@@ -814,7 +814,7 @@ Prefab:
     - target: {fileID: 3380982, guid: 4d293c8e162f3874b982baadd71153d2, type: 2}
       propertyPath: m_Mesh
       value: 
-      objectReference: {fileID: 414083819}
+      objectReference: {fileID: 28898311}
     - target: {fileID: 11489174, guid: 4d293c8e162f3874b982baadd71153d2, type: 2}
       propertyPath: drawInGame
       value: 1
@@ -887,6 +887,10 @@ Prefab:
       propertyPath: vertices.Array.data[7].z
       value: 0.9000001
       objectReference: {fileID: 0}
+    - target: {fileID: 2348914, guid: 4d293c8e162f3874b982baadd71153d2, type: 2}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 1307382741}
     m_RemovedComponents:
     - {fileID: 11411836, guid: 4d293c8e162f3874b982baadd71153d2, type: 2}
   m_ParentPrefab: {fileID: 100100000, guid: 4d293c8e162f3874b982baadd71153d2, type: 2}
@@ -922,11 +926,14 @@ MonoBehaviour:
   distanceBlinkDelay: 0
   headsetPositionCompensation: 1
   ignoreTargetWithTagOrClass: 
+  targetTagOrScriptListPolicy: {fileID: 0}
   navMeshLimitDistance: 0
   playSpaceFalling: 1
+  playSpaceFallRestriction: 0
   useGravity: 0
   gravityFallHeight: 1
   blinkYThreshold: 0.1
+  floorHeightTolerance: 0.001
 --- !u!114 &470380173
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -945,6 +952,7 @@ MonoBehaviour:
   uiClickButton: 3
   menuToggleButton: 7
   axisFidelity: 1
+  triggerClickThreshold: 1
   triggerPressed: 0
   triggerTouched: 0
   triggerHairlinePressed: 0
@@ -990,6 +998,7 @@ MonoBehaviour:
   uiClickButton: 3
   menuToggleButton: 7
   axisFidelity: 1
+  triggerClickThreshold: 1
   triggerPressed: 0
   triggerTouched: 0
   triggerHairlinePressed: 0
@@ -1028,41 +1037,6 @@ MonoBehaviour:
   _ears: {fileID: 470380176}
   wireframe: 0
   flip: {fileID: 0}
---- !u!114 &470380179
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 470380177}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2f0ad608ee982c348aaa6aea32a3db61, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  enableTeleport: 1
-  controller: {fileID: 470380173}
-  pointerMaterial: {fileID: 0}
-  pointerHitColor: {r: 0, g: 0.5, b: 0, a: 1}
-  pointerMissColor: {r: 0.8, g: 0, b: 0, a: 1}
-  showPlayAreaCursor: 1
-  playAreaCursorDimensions: {x: 0, y: 0}
-  handlePlayAreaCursorCollisions: 0
-  ignoreTargetWithTagOrClass: 
-  pointerVisibility: 2
-  holdButtonToActivate: 1
-  activateDelay: 0
-  pointerLength: 7
-  pointerDensity: 1
-  showPointerCursor: 1
-  pointerCursorRadius: 0.3
-  beamCurveOffset: 1
-  customPointerTracer: {fileID: 0}
-  customPointerCursor: {fileID: 0}
-  layersToIgnore:
-    serializedVersion: 2
-    m_Bits: 4
-  validTeleportLocationObject: {fileID: 0}
-  rescalePointerTracer: 0
 --- !u!1 &515507800
 GameObject:
   m_ObjectHideFlags: 0
@@ -1739,6 +1713,35 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1214114803}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!21 &1307382741
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Sprites/Default
+  m_Shader: {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 5
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  m_SavedProperties:
+    serializedVersion: 2
+    m_TexEnvs:
+    - first:
+        name: _MainTex
+      second:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - first:
+        name: PixelSnap
+      second: 0
+    m_Colors:
+    - first:
+        name: _Color
+      second: {r: 1, g: 1, b: 1, a: 1}
 --- !u!1 &1327507133
 GameObject:
   m_ObjectHideFlags: 0
@@ -2258,10 +2261,6 @@ MonoBehaviour:
   pointerMaterial: {fileID: 0}
   pointerHitColor: {r: 0, g: 0.5, b: 0, a: 1}
   pointerMissColor: {r: 0.8, g: 0, b: 0, a: 1}
-  showPlayAreaCursor: 0
-  playAreaCursorDimensions: {x: 0, y: 0}
-  handlePlayAreaCursorCollisions: 0
-  ignoreTargetWithTagOrClass: 
   pointerVisibility: 0
   holdButtonToActivate: 1
   activateDelay: 0

--- a/Assets/VRTK/Examples/Resources/Scripts/Setup_Scene_031.cs
+++ b/Assets/VRTK/Examples/Resources/Scripts/Setup_Scene_031.cs
@@ -12,12 +12,15 @@
             if (!initalised)
             {
                 var headset = VRTK_DeviceFinder.HeadsetTransform();
+                if (!headset.GetComponent<VRTK_PlayAreaCursor>())
+                {
+                    headset.gameObject.AddComponent<VRTK_PlayAreaCursor>();
+                }
                 if (!headset.GetComponent<VRTK_BezierPointer>())
                 {
                     var pointer = headset.gameObject.AddComponent<VRTK_BezierPointer>();
 
                     pointer.controller = VRTK_DeviceFinder.GetControllerRightHand().GetComponent<VRTK_ControllerEvents>();
-                    pointer.showPlayAreaCursor = true;
                     pointer.pointerVisibility = VRTK_WorldPointer.pointerVisibilityStates.Always_Off;
                     pointer.pointerLength = 7f;
                     pointer.pointerDensity = 1;

--- a/Assets/VRTK/Scripts/VRTK_BezierPointer.cs
+++ b/Assets/VRTK/Scripts/VRTK_BezierPointer.cs
@@ -16,8 +16,6 @@ namespace VRTK
     /// <example>
     /// `VRTK/Examples/009_Controller_BezierPointer` is used in conjunction with the Height Adjust Teleporter shows how it is possible to traverse different height objects using the curved pointer without needing to see the top of the object.
     ///
-    /// `VRTK/Examples/012_Controller_PointerWithAreaCollision` shows how a Bezier Pointer with the Play Area Cursor and Collision Detection enabled can be used to traverse a game area but not allow teleporting into areas where the walls or other objects would fall into the play area space enabling the user to enter walls.
-    ///
     /// `VRTK/Examples/036_Controller_CustomCompoundPointer' shows how to display an object (a teleport beam) only if the teleport location is valid, and can create an animated trail along the tracer curve.
     /// </example>
     public class VRTK_BezierPointer : VRTK_WorldPointer
@@ -204,9 +202,8 @@ namespace VRTK
         private void TogglePointerCursor(bool state)
         {
             var pointerCursorState = (showPointerCursor && state ? showPointerCursor : false);
-            var playAreaCursorState = (showPlayAreaCursor && state ? showPlayAreaCursor : false);
             pointerCursor.gameObject.SetActive(pointerCursorState);
-            base.TogglePointer(playAreaCursorState);
+            base.TogglePointer(state);
         }
 
         private Vector3 ProjectForwardBeam()
@@ -293,7 +290,7 @@ namespace VRTK
                 {
                     pointerCursor.transform.rotation = Quaternion.FromToRotation(Vector3.up, contactNormal);
                 }
-                base.SetPlayAreaCursorTransform(pointerCursor.transform.position);
+                base.UpdateDependencies(pointerCursor.transform.position);
                 UpdatePointerMaterial(pointerHitColor);
                 if (validTeleportLocationInstance != null)
                 {

--- a/Assets/VRTK/Scripts/VRTK_PlayAreaCursor.cs
+++ b/Assets/VRTK/Scripts/VRTK_PlayAreaCursor.cs
@@ -1,0 +1,271 @@
+﻿// Play Area Cursor|Scripts|0055
+namespace VRTK
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// The Play Area Cursor is used in conjunction with a World Pointer script and displays a representation of the play area where the pointer cursor hits.
+    /// </summary>
+    /// <example>
+    /// `VRTK/Examples/012_Controller_PointerWithAreaCollision` shows how a Bezier Pointer with the Play Area Cursor and Collision Detection enabled can be used to traverse a game area but not allow teleporting into areas where the walls or other objects would fall into the play area space enabling the user to enter walls.
+    /// </example>
+    public class VRTK_PlayAreaCursor : MonoBehaviour
+    {
+        [Tooltip("Determines the size of the play area cursor and collider. If the values are left as zero then the Play Area Cursor will be sized to the calibrated Play Area space.")]
+        public Vector2 playAreaCursorDimensions = Vector2.zero;
+        [Tooltip("If this is ticked then if the play area cursor is colliding with any other object then the pointer colour will change to the `Pointer Miss Color` and the `WorldPointerDestinationSet` event will not be triggered, which will prevent teleporting into areas where the play area will collide.")]
+        public bool handlePlayAreaCursorCollisions = false;
+        [Tooltip("A string that specifies an object Tag or the name of a Script attached to an object and notifies the play area cursor to ignore collisions with the object.")]
+        public string ignoreTargetWithTagOrClass;
+        [Tooltip("A specified VRTK_TagOrScriptPolicyList to use to determine whether the play area cursor collisions will be acted upon. If a list is provided then the 'Ignore Target With Tag Or Class' parameter will be ignored.")]
+        public VRTK_TagOrScriptPolicyList targetTagOrScriptListPolicy;
+
+        private bool headsetPositionCompensation;
+        private bool playAreaCursorCollided = false;
+        private Transform playArea;
+        private GameObject playAreaCursor;
+        private GameObject[] playAreaCursorBoundaries;
+        private BoxCollider playAreaCursorCollider;
+        private Transform headset;
+
+        /// <summary>
+        /// The HasCollided method returns the state of whether the play area cursor has currently collided with another valid object.
+        /// </summary>
+        /// <returns>A bool to determine the state of collision. `true` if the play area is colliding with a valid object and `false` if not.</returns>
+        public virtual bool HasCollided()
+        {
+            return playAreaCursorCollided;
+        }
+
+        /// <summary>
+        /// The SetHeadsetPositionCompensation method determines whether the offset position of the headset from the centre of the play area should be taken into consideration when setting the destination marker. If `true` then it will take the offset position into consideration.
+        /// </summary>
+        /// <param name="state">The state of whether to take the position of the headset within the play area into account when setting the destination marker.</param>
+        public virtual void SetHeadsetPositionCompensation(bool state)
+        {
+            headsetPositionCompensation = state;
+        }
+
+        /// <summary>
+        /// The SetPlayAreaCursorCollision method determines whether play area collisions should be taken into consideration with the play area cursor.
+        /// </summary>
+        /// <param name="state">The state of whether to check for play area collisions.</param>
+        public virtual void SetPlayAreaCursorCollision(bool state)
+        {
+            playAreaCursorCollided = false;
+            state = (!enabled ? false : state);
+            if (handlePlayAreaCursorCollisions)
+            {
+                playAreaCursorCollided = state;
+            }
+        }
+
+        /// <summary>
+        /// The SetMaterial method sets the current material on the play area cursor.
+        /// </summary>
+        /// <param name="material">The material to update the play area cursor to.</param>
+        public virtual void SetMaterial(Material material)
+        {
+            foreach (GameObject playAreaCursorBoundary in playAreaCursorBoundaries)
+            {
+                playAreaCursorBoundary.GetComponent<Renderer>().material = material;
+            }
+        }
+
+        /// <summary>
+        /// The SetPlayAreaCursorTransform method is used to update the position of the play area cursor in world space to the given location.
+        /// </summary>
+        /// <param name="location">The location where to draw the play area cursor.</param>
+        public virtual void SetPlayAreaCursorTransform(Vector3 location)
+        {
+            var offset = Vector3.zero;
+            if (headsetPositionCompensation)
+            {
+                var playAreaPos = new Vector3(playArea.transform.position.x, 0f, playArea.transform.position.z);
+                var headsetPos = new Vector3(headset.position.x, 0f, headset.position.z);
+                offset = playAreaPos - headsetPos;
+            }
+            playAreaCursor.transform.position = location + offset;
+        }
+
+        /// <summary>
+        /// The ToggleState method enables or disables the visibility of the play area cursor.
+        /// </summary>
+        /// <param name="state">The state of whether to show or hide the play area cursor.</param>
+        public virtual void ToggleState(bool state)
+        {
+            state = (!enabled ? false : state);
+            playAreaCursor.SetActive(state);
+        }
+
+        protected virtual void Awake()
+        {
+            if (!GetComponent<VRTK_WorldPointer>())
+            {
+                Debug.LogError("VRTK_PlayAreaCursor requires a VRTK_WorldPointer script attached to the same object.");
+                return;
+            }
+
+            Utilities.SetPlayerObject(gameObject, VRTK_PlayerObject.ObjectTypes.Pointer);
+
+            headset = VRTK_DeviceFinder.HeadsetTransform();
+            playArea = VRTK_DeviceFinder.PlayAreaTransform();
+            playAreaCursorBoundaries = new GameObject[4];
+            InitPlayAreaCursor();
+        }
+
+        protected virtual void Destroy()
+        {
+            if (playAreaCursor != null)
+            {
+                Destroy(playAreaCursor);
+            }
+        }
+
+        protected virtual void Update()
+        {
+            if (enabled && playAreaCursor && playAreaCursor.activeInHierarchy)
+            {
+                UpdateCollider();
+            }
+        }
+
+        private void DrawPlayAreaCursorBoundary(int index, float left, float right, float top, float bottom, float thickness, Vector3 localPosition)
+        {
+            var playAreaCursorBoundary = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            playAreaCursorBoundary.name = string.Format("[{0}]PlayAreaCursorBoundary_" + index, gameObject.name);
+            Utilities.SetPlayerObject(playAreaCursorBoundary, VRTK_PlayerObject.ObjectTypes.Pointer);
+
+            var width = (right - left) / 1.065f;
+            var length = (top - bottom) / 1.08f;
+            var height = thickness;
+
+            playAreaCursorBoundary.transform.localScale = new Vector3(width, height, length);
+            Destroy(playAreaCursorBoundary.GetComponent<BoxCollider>());
+            playAreaCursorBoundary.layer = LayerMask.NameToLayer("Ignore Raycast");
+
+            playAreaCursorBoundary.transform.parent = playAreaCursor.transform;
+            playAreaCursorBoundary.transform.localPosition = localPosition;
+
+            playAreaCursorBoundaries[index] = playAreaCursorBoundary;
+        }
+
+        private void InitPlayAreaCursor()
+        {
+            var btmRightInner = 0;
+            var btmLeftInner = 1;
+            var topLeftInner = 2;
+            var topRightInner = 3;
+
+            var btmRightOuter = 4;
+            var btmLeftOuter = 5;
+            var topLeftOuter = 6;
+            var topRightOuter = 7;
+
+            Vector3[] cursorDrawVertices = VRTK_SDK_Bridge.GetPlayAreaVertices(playArea.gameObject);
+
+            if (playAreaCursorDimensions != Vector2.zero)
+            {
+                var customAreaPadding = VRTK_SDK_Bridge.GetPlayAreaBorderThickness(playArea.gameObject);
+
+                cursorDrawVertices[btmRightOuter] = new Vector3(playAreaCursorDimensions.x / 2, 0f, (playAreaCursorDimensions.y / 2) * -1);
+                cursorDrawVertices[btmLeftOuter] = new Vector3((playAreaCursorDimensions.x / 2) * -1, 0f, (playAreaCursorDimensions.y / 2) * -1);
+                cursorDrawVertices[topLeftOuter] = new Vector3((playAreaCursorDimensions.x / 2) * -1, 0f, playAreaCursorDimensions.y / 2);
+                cursorDrawVertices[topRightOuter] = new Vector3(playAreaCursorDimensions.x / 2, 0f, playAreaCursorDimensions.y / 2);
+
+                cursorDrawVertices[btmRightInner] = cursorDrawVertices[btmRightOuter] + new Vector3(-customAreaPadding, 0f, customAreaPadding);
+                cursorDrawVertices[btmLeftInner] = cursorDrawVertices[btmLeftOuter] + new Vector3(customAreaPadding, 0f, customAreaPadding);
+                cursorDrawVertices[topLeftInner] = cursorDrawVertices[topLeftOuter] + new Vector3(customAreaPadding, 0f, -customAreaPadding);
+                cursorDrawVertices[topRightInner] = cursorDrawVertices[topRightOuter] + new Vector3(-customAreaPadding, 0f, -customAreaPadding);
+            }
+
+            var width = cursorDrawVertices[btmRightOuter].x - cursorDrawVertices[topLeftOuter].x;
+            var length = cursorDrawVertices[topLeftOuter].z - cursorDrawVertices[btmRightOuter].z;
+            var height = 0.01f;
+
+            playAreaCursor = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            playAreaCursor.name = string.Format("[{0}]PlayAreaCursor", gameObject.name);
+            Utilities.SetPlayerObject(playAreaCursor, VRTK_PlayerObject.ObjectTypes.Pointer);
+            playAreaCursor.transform.parent = null;
+            playAreaCursor.transform.localScale = new Vector3(width, height, length);
+            playAreaCursor.SetActive(false);
+
+            playAreaCursor.GetComponent<Renderer>().enabled = false;
+
+            CreateCursorCollider(playAreaCursor);
+
+            playAreaCursor.AddComponent<Rigidbody>().isKinematic = true;
+
+            var playAreaCursorScript = playAreaCursor.AddComponent<VRTK_PlayAreaCollider>();
+            playAreaCursorScript.SetParent(gameObject);
+            playAreaCursorScript.SetIgnoreTarget(ignoreTargetWithTagOrClass, targetTagOrScriptListPolicy);
+            playAreaCursor.layer = LayerMask.NameToLayer("Ignore Raycast");
+
+            var playAreaBoundaryX = playArea.transform.localScale.x / 2;
+            var playAreaBoundaryZ = playArea.transform.localScale.z / 2;
+            var heightOffset = 0f;
+
+            DrawPlayAreaCursorBoundary(0, cursorDrawVertices[btmLeftOuter].x, cursorDrawVertices[btmRightOuter].x, cursorDrawVertices[btmRightInner].z, cursorDrawVertices[btmRightOuter].z, height, new Vector3(0f, heightOffset, playAreaBoundaryZ));
+            DrawPlayAreaCursorBoundary(1, cursorDrawVertices[btmLeftOuter].x, cursorDrawVertices[btmLeftInner].x, cursorDrawVertices[topLeftOuter].z, cursorDrawVertices[btmLeftOuter].z, height, new Vector3(playAreaBoundaryX, heightOffset, 0f));
+            DrawPlayAreaCursorBoundary(2, cursorDrawVertices[btmLeftOuter].x, cursorDrawVertices[btmRightOuter].x, cursorDrawVertices[btmRightInner].z, cursorDrawVertices[btmRightOuter].z, height, new Vector3(0f, heightOffset, -playAreaBoundaryZ));
+            DrawPlayAreaCursorBoundary(3, cursorDrawVertices[btmLeftOuter].x, cursorDrawVertices[btmLeftInner].x, cursorDrawVertices[topLeftOuter].z, cursorDrawVertices[btmLeftOuter].z, height, new Vector3(-playAreaBoundaryX, heightOffset, 0f));
+        }
+
+        private void CreateCursorCollider(GameObject cursor)
+        {
+            playAreaCursorCollider = cursor.GetComponent<BoxCollider>();
+            playAreaCursorCollider.isTrigger = true;
+            playAreaCursorCollider.center = new Vector3(0f, 65f, 0f);
+            playAreaCursorCollider.size = new Vector3(1f, 1f, 1f);
+        }
+
+        private void UpdateCollider()
+        {
+            var playAreaHeightAdjustment = 1f;
+            var newBCYSize = (headset.transform.position.y - playArea.transform.position.y) * 100f;
+            var newBCYCenter = (newBCYSize != 0 ? (newBCYSize / 2) + playAreaHeightAdjustment : 0);
+
+            playAreaCursorCollider.size = new Vector3(playAreaCursorCollider.size.x, newBCYSize, playAreaCursorCollider.size.z);
+            playAreaCursorCollider.center = new Vector3(playAreaCursorCollider.center.x, newBCYCenter, playAreaCursorCollider.center.z);
+        }
+    }
+
+    public class VRTK_PlayAreaCollider : MonoBehaviour
+    {
+        private VRTK_PlayAreaCursor parent;
+        private string ignoreTargetWithTagOrClass;
+        private VRTK_TagOrScriptPolicyList targetTagOrScriptListPolicy;
+
+        public void SetParent(GameObject setParent)
+        {
+            parent = setParent.GetComponent<VRTK_PlayAreaCursor>();
+        }
+
+        public void SetIgnoreTarget(string ignore, VRTK_TagOrScriptPolicyList list = null)
+        {
+            ignoreTargetWithTagOrClass = ignore;
+            targetTagOrScriptListPolicy = list;
+        }
+
+        private bool ValidTarget(Collider collider)
+        {
+            return (!collider.GetComponent<VRTK_PlayerObject>() && !(Utilities.TagOrScriptCheck(collider.gameObject, targetTagOrScriptListPolicy, ignoreTargetWithTagOrClass)));
+        }
+
+        private void OnTriggerStay(Collider collider)
+        {
+            if (parent.enabled && parent.gameObject.activeInHierarchy && ValidTarget(collider))
+            {
+                parent.SetPlayAreaCursorCollision(true);
+            }
+        }
+
+        private void OnTriggerExit(Collider collider)
+        {
+            if (ValidTarget(collider))
+            {
+                parent.SetPlayAreaCursorCollision(false);
+            }
+        }
+    }
+}

--- a/Assets/VRTK/Scripts/VRTK_PlayAreaCursor.cs.meta
+++ b/Assets/VRTK/Scripts/VRTK_PlayAreaCursor.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 9d7236ea6e01c074ba249e564af997a0
+timeCreated: 1475140565
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRTK/Scripts/VRTK_SimplePointer.cs
+++ b/Assets/VRTK/Scripts/VRTK_SimplePointer.cs
@@ -149,7 +149,7 @@ namespace VRTK
             pointer.transform.localPosition = new Vector3(0f, 0f, beamPosition);
             pointerTip.transform.localPosition = new Vector3(0f, 0f, setLength - (pointerTip.transform.localScale.z / 2));
             pointerHolder.transform.localRotation = Quaternion.identity;
-            base.SetPlayAreaCursorTransform(pointerTip.transform.position);
+            base.UpdateDependencies(pointerTip.transform.position);
         }
 
         private float GetPointerBeamLength(bool hasRayHit, RaycastHit collidedWith)

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -332,11 +332,6 @@ The play area collider does not work well with terrains as they are uneven and c
 
  * **Controller:** The controller that will be used to toggle the pointer. If the script is being applied onto a controller then this parameter can be left blank as it will be auto populated by the controller the script is on at runtime.
  * **Pointer Material:** The material to use on the rendered version of the pointer. If no material is selected then the default `WorldPointer` material will be used.
- * **Show Play Area Cursor:** If this is enabled then the play area boundaries are displayed at the tip of the pointer beam in the current pointer colour.
- * **Play Area Cursor Dimensions:** Determines the size of the play area cursor and collider. If the values are left as zero then the Play Area Cursor will be sized to the calibrated Play Area space.
- * **Handle Play Area Cursor Collisions:** If this is ticked then if the play area cursor is colliding with any other object then the pointer colour will change to the `Pointer Miss Color` and the `WorldPointerDestinationSet` event will not be triggered, which will prevent teleporting into areas where the play area will collide.
- * **Ignore Target With Tag Or Class:** A string that specifies an object Tag or the name of a Script attached to an object and notifies the play area cursor to ignore collisions with the object.
- * **Target Tag Or Script List Policy:** A specified VRTK_TagOrScriptPolicyList to use to determine whether the play area cursor collisions will be acted upon. If a list is provided then the 'Ignore Target With Tag Or Class' parameter will be ignored.
  * **Pointer Visibility:** Determines when the pointer beam should be displayed.
  * **Hold Button To Activate:** If this is checked then the pointer beam will be activated on first press of the pointer alias button and will stay active until the pointer alias button is pressed again. The destination set event is emitted when the beam is deactivated on the second button press.
  * **Activate Delay:** The time in seconds to delay the pointer beam being able to be active again. Useful for preventing constant teleportation.
@@ -349,17 +344,6 @@ The play area collider does not work well with terrains as they are uneven and c
   * `Always_Off` - Ensures the pointer beam is never visible but the destination point is still set and pressing the Pointer button on the controller still initiates the destination set event.
 
 ### Class Methods
-
-#### setPlayAreaCursorCollision/1
-
-  > `public virtual void setPlayAreaCursorCollision(bool state)`
-
-  * Parameters
-   * `bool state` - The state of whether to check for play area collisions.
-  * Returns
-   * _none_
-
-The setPlayAreaCursorCollision method determines whether play area collisions should be taken into consideration with the play area cursor.
 
 #### IsActive/0
 
@@ -607,6 +591,7 @@ This directory contains all of the toolkit scripts that add VR functionality to 
  * [Device Finder](#device-finder-vrtk_devicefinder)
  * [Simple Pointer](#simple-pointer-vrtk_simplepointer)
  * [Bezier Pointer](#bezier-pointer-vrtk_bezierpointer)
+ * [Play Area Cursor](#play-area-cursor-vrtk_playareacursor)
  * [UI Pointer](#ui-pointer-vrtk_uipointer)
  * [Basic Teleport](#basic-teleport-vrtk_basicteleport)
  * [Height Adjust Teleport](#height-adjust-teleport-vrtk_heightadjustteleport)
@@ -1329,9 +1314,94 @@ The Bezier Pointer script can be attached to a Controller object within the `[Ca
 
 `VRTK/Examples/009_Controller_BezierPointer` is used in conjunction with the Height Adjust Teleporter shows how it is possible to traverse different height objects using the curved pointer without needing to see the top of the object.
 
-`VRTK/Examples/012_Controller_PointerWithAreaCollision` shows how a Bezier Pointer with the Play Area Cursor and Collision Detection enabled can be used to traverse a game area but not allow teleporting into areas where the walls or other objects would fall into the play area space enabling the user to enter walls.
-
 `VRTK/Examples/036_Controller_CustomCompoundPointer' shows how to display an object (a teleport beam) only if the teleport location is valid, and can create an animated trail along the tracer curve.
+
+---
+
+## Play Area Cursor (VRTK_PlayAreaCursor)
+
+### Overview
+
+The Play Area Cursor is used in conjunction with a World Pointer script and displays a representation of the play area where the pointer cursor hits.
+
+### Inspector Parameters
+
+ * **Play Area Cursor Dimensions:** Determines the size of the play area cursor and collider. If the values are left as zero then the Play Area Cursor will be sized to the calibrated Play Area space.
+ * **Handle Play Area Cursor Collisions:** If this is ticked then if the play area cursor is colliding with any other object then the pointer colour will change to the `Pointer Miss Color` and the `WorldPointerDestinationSet` event will not be triggered, which will prevent teleporting into areas where the play area will collide.
+ * **Ignore Target With Tag Or Class:** A string that specifies an object Tag or the name of a Script attached to an object and notifies the play area cursor to ignore collisions with the object.
+ * **Target Tag Or Script List Policy:** A specified VRTK_TagOrScriptPolicyList to use to determine whether the play area cursor collisions will be acted upon. If a list is provided then the 'Ignore Target With Tag Or Class' parameter will be ignored.
+
+### Class Methods
+
+#### HasCollided/0
+
+  > `public virtual bool HasCollided()`
+
+  * Parameters
+   * _none_
+  * Returns
+   * `bool` - A bool to determine the state of collision. `true` if the play area is colliding with a valid object and `false` if not.
+
+The HasCollided method returns the state of whether the play area cursor has currently collided with another valid object.
+
+#### SetHeadsetPositionCompensation/1
+
+  > `public virtual void SetHeadsetPositionCompensation(bool state)`
+
+  * Parameters
+   * `bool state` - The state of whether to take the position of the headset within the play area into account when setting the destination marker.
+  * Returns
+   * _none_
+
+The SetHeadsetPositionCompensation method determines whether the offset position of the headset from the centre of the play area should be taken into consideration when setting the destination marker. If `true` then it will take the offset position into consideration.
+
+#### SetPlayAreaCursorCollision/1
+
+  > `public virtual void SetPlayAreaCursorCollision(bool state)`
+
+  * Parameters
+   * `bool state` - The state of whether to check for play area collisions.
+  * Returns
+   * _none_
+
+The SetPlayAreaCursorCollision method determines whether play area collisions should be taken into consideration with the play area cursor.
+
+#### SetMaterial/1
+
+  > `public virtual void SetMaterial(Material material)`
+
+  * Parameters
+   * `Material material` - The material to update the play area cursor to.
+  * Returns
+   * _none_
+
+The SetMaterial method sets the current material on the play area cursor.
+
+#### SetPlayAreaCursorTransform/1
+
+  > `public virtual void SetPlayAreaCursorTransform(Vector3 location)`
+
+  * Parameters
+   * `Vector3 location` - The location where to draw the play area cursor.
+  * Returns
+   * _none_
+
+The SetPlayAreaCursorTransform method is used to update the position of the play area cursor in world space to the given location.
+
+#### ToggleState/1
+
+  > `public virtual void ToggleState(bool state)`
+
+  * Parameters
+   * `bool state` - The state of whether to show or hide the play area cursor.
+  * Returns
+   * _none_
+
+The ToggleState method enables or disables the visibility of the play area cursor.
+
+### Example
+
+`VRTK/Examples/012_Controller_PointerWithAreaCollision` shows how a Bezier Pointer with the Play Area Cursor and Collision Detection enabled can be used to traverse a game area but not allow teleporting into areas where the walls or other objects would fall into the play area space enabling the user to enter walls.
 
 ---
 


### PR DESCRIPTION
This commit brings some breaking changes to the World Pointer script.

The Play Area Cursor used to be part of the World Pointer script but
this meant the play area cursor was coupled to the pointer script and
meant that adding custon play area cursors would mean changing core
code.

A new `VRTK_PlayAreaCursor` script has now been added that can be
applied to the same game object that a World Poiinter component is
applied to. If the Play Area Cursor is applied then it works the same
way as previously, with the same options just moved into the new
script.