### PR TITLE
fix(Simulator): inconsistent vector addition.

### DIFF
--- a/Assets/VRTK/Scripts/VRTK_Simulator.cs
+++ b/Assets/VRTK/Scripts/VRTK_Simulator.cs
@@ -107,7 +107,7 @@ namespace VRTK
                 transform.position = initialPosition;
                 transform.rotation = initialRotation;
             }
-            transform.Translate(movDir * stepSize);
+            transform.Translate(movDir * stepSize, Space.World);
             transform.Rotate(rotDir);
         }
 


### PR DESCRIPTION
Fixed inconsistency in vector addition caused by adding a vector in world space (the camera forward) to a vector in local space (the camera rig's basis vectors).  Doing the math in the same space gives the intended result.