### PR TITLE
fix(RadialMenu): only change the axis if the touchpad is being touched

### DIFF
--- a/Assets/VRTK/Scripts/Controls/2D/RadialMenuController.cs
+++ b/Assets/VRTK/Scripts/Controls/2D/RadialMenuController.cs
@@ -10,6 +10,7 @@ namespace VRTK
 
         protected RadialMenu menu;
         private float currentAngle; //Keep track of angle for when we click
+        private bool touchpadTouched;
 
         private void Awake()
         {
@@ -108,18 +109,23 @@ namespace VRTK
 
         private void DoTouchpadTouched(object sender, ControllerInteractionEventArgs e)
         {
+            touchpadTouched = true;
             DoShowMenu(CalculateAngle(e));
         }
 
         private void DoTouchpadUntouched(object sender, ControllerInteractionEventArgs e)
         {
+            touchpadTouched = false;
             DoHideMenu(false);
         }
 
         //Touchpad finger moved position
         private void DoTouchpadAxisChanged(object sender, ControllerInteractionEventArgs e)
         {
-            DoChangeAngle(CalculateAngle(e));
+            if (touchpadTouched)
+            {
+                DoChangeAngle(CalculateAngle(e));
+            }
         }
 
         #endregion Private Controller Listeners


### PR DESCRIPTION
SteamVR seems to sent a TouchpadAxisChanged event when the touchpad
is released. This is causing an OnOverEnter event to fire out of the
RadialMenu after the OnHoverExit event is fired. Because of this,
you'll always get an OnHoverEnter event at the end of picking your
finger up off of the touchpad.

Keep track of if the touchpad is currently being touched or not. Only
trigger the axis change if it is during an active touch.