### PR TITLE
fix(Interaction): scan also inactive objects in color highlighter

### DIFF
--- a/Assets/VRTK/Scripts/Highlighters/VRTK_MaterialColorSwapHighlighter.cs
+++ b/Assets/VRTK/Scripts/Highlighters/VRTK_MaterialColorSwapHighlighter.cs
@@ -77,7 +77,7 @@ namespace VRTK.Highlighters
             }
             faderRoutines.Clear();
 
-            foreach (Renderer renderer in GetComponentsInChildren<Renderer>())
+            foreach (Renderer renderer in GetComponentsInChildren<Renderer>(true))
             {
                 var objectReference = renderer.gameObject.GetInstanceID().ToString();
                 if (!originalRendererMaterials.ContainsKey(objectReference))
@@ -94,7 +94,7 @@ namespace VRTK.Highlighters
         {
             originalSharedRendererMaterials.Clear();
             originalRendererMaterials.Clear();
-            foreach (Renderer renderer in GetComponentsInChildren<Renderer>())
+            foreach (Renderer renderer in GetComponentsInChildren<Renderer>(true))
             {
                 var objectReference = renderer.gameObject.GetInstanceID().ToString();
                 originalSharedRendererMaterials[objectReference] = renderer.sharedMaterials;
@@ -105,7 +105,7 @@ namespace VRTK.Highlighters
 
         private void ChangeToHighlightColor(Color color, float duration = 0f)
         {
-            foreach (Renderer renderer in GetComponentsInChildren<Renderer>())
+            foreach (Renderer renderer in GetComponentsInChildren<Renderer>(true))
             {
                 for (int i = 0; i < renderer.materials.Length; i++)
                 {


### PR DESCRIPTION
Add true parameter to GetComponentsInChildren to store/restore materials
also for inactive object (in VRTK_MaterialColorSwapHighlighter).

If a script sets some inactive objects as active after highlighting an
object, when that object is unhighlighted the colors of the previously
inactive objects are not restored. This PR fixes this issue.