### PR TITLE
fix(Interaction): objectHighlighter not initialized in ToggleHighlight

### DIFF
--- a/Assets/VRTK/Scripts/VRTK_InteractableObject.cs
+++ b/Assets/VRTK/Scripts/VRTK_InteractableObject.cs
@@ -405,6 +405,10 @@ namespace VRTK
         /// <param name="globalHighlightColor">The colour to use when highlighting the object.</param>
         public virtual void ToggleHighlight(bool toggle, Color globalHighlightColor)
         {
+            if (highlightOnTouch && objectHighlighter == null)
+            {
+                InitialiseHighlighter();
+            }
             if (highlightOnTouch)
             {
                 if (toggle && !IsGrabbed())
@@ -650,6 +654,7 @@ namespace VRTK
             if (autoHighlighter)
             {
                 Destroy(objectHighlighter);
+                objectHighlighter = null;
             }
             forceDisabled = true;
             ForceStopInteracting();


### PR DESCRIPTION
Add a check on objectHighlighter in
VRTK_InteractableObject.ToggleHighlight.

Set objectHighlighter to null after it is destroyed in OnDisable().

With a `NetworkManager` active and if a `NetworkIdentity` component is
added to the same game object holding `VRTK_InteractableObject`, then
`VRTK_InteractableObject.objectHighlighter` is destroyed before the
object is touched.
This is a workaround to ensure objectHighlighter is initialized anyway.