### PR TITLE
feat(Interaction): support moving drawers

### DIFF
--- a/Assets/VRTK/Scripts/Controls/3D/VRTK_Drawer.cs
+++ b/Assets/VRTK/Scripts/Controls/3D/VRTK_Drawer.cs
@@ -18,6 +18,8 @@ namespace VRTK
     /// </example>
     public class VRTK_Drawer : VRTK_Control
     {
+        [Tooltip("An optional game object to which the drawer will be connected. If the game object moves the drawer will follow along.")]
+        public GameObject connectedTo;
         [Tooltip("The axis on which the drawer should open. All other axis will be frozen.")]
         public Direction direction = Direction.autodetect;
         [Tooltip("The game object for the body.")]
@@ -153,6 +155,11 @@ namespace VRTK
                 SoftJointLimit limit = cj.linearLimit;
                 limit.limit = pullDistance;
                 cj.linearLimit = limit;
+
+                if (connectedTo)
+                {
+                    cj.connectedBody = connectedTo.GetComponent<Rigidbody>();
+                }
             }
             if (cfCreated)
             {
@@ -192,6 +199,17 @@ namespace VRTK
             io.precisionSnap = true;
             io.stayGrabbedOnTeleport = false;
             io.grabAttachMechanic = VRTK_InteractableObject.GrabAttachType.Spring_Joint;
+
+            if (connectedTo)
+            {
+                Rigidbody rb2 = connectedTo.GetComponent<Rigidbody>();
+                if (rb2 == null)
+                {
+                    rb2 = connectedTo.AddComponent<Rigidbody>();
+                    rb2.useGravity = false;
+                    rb2.isKinematic = true;
+                }
+            }
 
             cj = GetComponent<ConfigurableJoint>();
             if (cj == null)

--- a/Assets/VRTK/Scripts/Controls/3D/VRTK_Lever.cs
+++ b/Assets/VRTK/Scripts/Controls/3D/VRTK_Lever.cs
@@ -72,7 +72,7 @@ namespace VRTK
 
             if (connectedTo)
             {
-                Rigidbody rb2 = GetComponent<Rigidbody>();
+                Rigidbody rb2 = connectedTo.GetComponent<Rigidbody>();
                 if (rb2 == null)
                 {
                     rb2 = connectedTo.AddComponent<Rigidbody>();


### PR DESCRIPTION
This patch adds the ability to connect a drawer to another gameobject
similar to buttons and levers.

It also fixes a bug in the lever that was recently introduced, checking
on a different gameobject for the rigidbody than the one it will be
created on.